### PR TITLE
Client credential grant made possible

### DIFF
--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -62,12 +62,19 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
 #'     retrieve the token. Some authorization servers require this.
 #'     If \code{FALSE}, the default, retrieve the token by including the
 #'     app key and secret in the request body.
+#' @param without_auth_req if \code{TRUE}, no authorization request is send
+#'   before token access request. It is suitable for the \emph{Client Credential
+#'   Grant} as described in
+#'   \url{https://tools.ietf.org/html/rfc6749#section-4.4}. If \code{FALSE}, the
+#'   default, authorization request is then token request is send included the
+#'   authorization code.
 #' @export
 #' @keywords internal
 init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
                           type = NULL, use_oob = getOption("httr_oob_default"),
                           is_interactive = interactive(),
-                          use_basic_auth = FALSE) {
+                          use_basic_auth = FALSE,
+                          without_auth_req = FALSE) {
   if (!use_oob && !is_installed("httpuv")) {
     message("httpuv not installed, defaulting to out-of-band authentication")
     use_oob <- TRUE
@@ -84,18 +91,21 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
 
   scope_arg <- paste(scope, collapse = ' ')
 
-  authorize_url <- modify_url(endpoint$authorize, query = compact(list(
-    client_id = app$key,
-    scope = scope_arg,
-    redirect_uri = redirect_uri,
-    response_type = "code",
-    state = state)))
-  if (isTRUE(use_oob)) {
-    code <- oauth_exchanger(authorize_url)$code
-  } else {
-    code <- oauth_listener(authorize_url, is_interactive)$code
-  }
-
+  # Some Oauth2 grant type not required an authentification request
+  # (see https://tools.ietf.org/html/rfc6749#section-4.4)
+  if(!without_auth_req) {
+    authorize_url <- modify_url(endpoint$authorize, query = compact(list(
+      client_id = app$key,
+      scope = scope_arg,
+      redirect_uri = redirect_uri,
+      response_type = "code",
+      state = state)))
+    if (isTRUE(use_oob)) {
+      code <- oauth_exchanger(authorize_url)$code
+    } else {
+      code <- oauth_listener(authorize_url, is_interactive)$code
+    }
+  } else
   # Use authorisation code to get (temporary) access token
 
   # Send credentials using HTTP Basic or as parameters in the request body
@@ -105,6 +115,8 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
     redirect_uri = redirect_uri,
     grant_type = "authorization_code",
     code = code)
+
+  if(without_auth_req) req_params <- NULL
 
   if (!is.null(user_params)) {
     req_params <- utils::modifyList(user_params, req_params)

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -105,18 +105,26 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
     } else {
       code <- oauth_listener(authorize_url, is_interactive)$code
     }
-  } else
+  }
   # Use authorisation code to get (temporary) access token
 
   # Send credentials using HTTP Basic or as parameters in the request body
   # See https://tools.ietf.org/html/rfc6749#section-2.3 (Client Authentication)
-  req_params <- list(
-    client_id = app$key,
-    redirect_uri = redirect_uri,
-    grant_type = "authorization_code",
-    code = code)
 
-  if(without_auth_req) req_params <- NULL
+
+  if(without_auth_req) {
+    req_params <- list(
+      client_id = app$key,
+      client_secret = app$secret,
+      # redirect_uri = redirect_uri,
+      grant_type = "client_credentials")
+  } else {
+    req_params <- list(
+      client_id = app$key,
+      redirect_uri = redirect_uri,
+      grant_type = "authorization_code",
+      code = code)
+  }
 
   if (!is.null(user_params)) {
     req_params <- utils::modifyList(user_params, req_params)

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -201,7 +201,8 @@ oauth2.0_token <- function(endpoint, app, scope = NULL, user_params = NULL,
                            cache = getOption("httr_oauth_cache")) {
   params <- list(scope = scope, user_params = user_params, type = type,
       use_oob = use_oob, as_header = as_header,
-      use_basic_auth = use_basic_auth)
+      use_basic_auth = use_basic_auth,
+      without_auth_req = without_auth_req)
 
   Token2.0$new(app = app, endpoint = endpoint, params = params,
     cache_path = cache)
@@ -214,7 +215,8 @@ Token2.0 <- R6::R6Class("Token2.0", inherit = Token, list(
     self$credentials <- init_oauth2.0(self$endpoint, self$app,
       scope = self$params$scope, user_params = self$params$user_params,
       type = self$params$type, use_oob = self$params$use_oob,
-      use_basic_auth = self$params$use_basic_auth)
+      use_basic_auth = self$params$use_basic_auth,
+      without_auth_req = self$params$without_auth_req)
   },
   can_refresh = function() {
     !is.null(self$credentials$refresh_token)

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -197,6 +197,7 @@ oauth2.0_token <- function(endpoint, app, scope = NULL, user_params = NULL,
                            type = NULL, use_oob = getOption("httr_oob_default"),
                            as_header = TRUE,
                            use_basic_auth = FALSE,
+                           without_auth_req = FALSE,
                            cache = getOption("httr_oauth_cache")) {
   params <- list(scope = scope, user_params = user_params, type = type,
       use_oob = use_oob, as_header = as_header,

--- a/man/init_oauth2.0.Rd
+++ b/man/init_oauth2.0.Rd
@@ -6,7 +6,8 @@
 \usage{
 init_oauth2.0(endpoint, app, scope = NULL, user_params = NULL,
   type = NULL, use_oob = getOption("httr_oob_default"),
-  is_interactive = interactive(), use_basic_auth = FALSE)
+  is_interactive = interactive(), use_basic_auth = FALSE,
+  without_auth_req = FALSE)
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -33,6 +34,13 @@ or \code{TRUE} if \code{httpuv} is not installed.}
 retrieve the token. Some authorization servers require this.
 If \code{FALSE}, the default, retrieve the token by including the
 app key and secret in the request body.}
+
+\item{without_auth_req}{if \code{TRUE}, no authorization request is send
+before token access request. It is suitable for the \emph{Client Credential
+Grant} as described in
+\url{https://tools.ietf.org/html/rfc6749#section-4.4}. If \code{FALSE}, the
+default, authorization request is then token request is send included the
+authorization code.}
 }
 \description{
 See demos for use.

--- a/man/oauth2.0_token.Rd
+++ b/man/oauth2.0_token.Rd
@@ -6,7 +6,8 @@
 \usage{
 oauth2.0_token(endpoint, app, scope = NULL, user_params = NULL,
   type = NULL, use_oob = getOption("httr_oob_default"), as_header = TRUE,
-  use_basic_auth = FALSE, cache = getOption("httr_oauth_cache"))
+  use_basic_auth = FALSE, without_auth_req = FALSE,
+  cache = getOption("httr_oauth_cache"))
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -36,6 +37,13 @@ requests.}
 retrieve the token. Some authorization servers require this.
 If \code{FALSE}, the default, retrieve the token by including the
 app key and secret in the request body.}
+
+\item{without_auth_req}{if \code{TRUE}, no authorization request is send
+before token access request. It is suitable for the \emph{Client Credential
+Grant} as described in
+\url{https://tools.ietf.org/html/rfc6749#section-4.4}. If \code{FALSE}, the
+default, authorization request is then token request is send included the
+authorization code.}
 
 \item{cache}{A logical value or a string. \code{TRUE} means to cache
 using the default cache file \code{.httr-oauth}, \code{FALSE} means


### PR DESCRIPTION
As explained in #384 , Oauth2 credential grant just need an access token request and then is not possible with `httr` oauth2 mechanism because authorization request is made at every call. 

In this PR, I just add an option to skip the part with an authorization request in order to make use of API with Oauth2 credential grant possible. 

Optional arg `without_auth_req` is set to `FALSE` by default to keep everyting else the same and not break anything.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hadley/httr/388)

<!-- Reviewable:end -->
