### PR TITLE
Allowing cacert bundle to be found in R_HOME/etc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr 1.2.1.9000
 
+* Fix bug with cert bundle lookup: `find_cert_bundle()` will now return cert bundle
+  in "R_HOME/etc" (@jiwalker-usgs #386).
+
 * `oauth_service_token()` gains a `sub` parameter so you can request
   access on behalf of another user (#410).
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -81,7 +81,7 @@ find_cert_bundle <- function() {
 
   bundled <- file.path(R.home("etc"), "curl-ca-bundle.crt")
   if (file.exists(bundled))
-    bundled
+    return(bundled)
 
   # Fall back to certificate bundle in openssl
   system.file("cacert.pem", package = "openssl")


### PR DESCRIPTION
quick fix for #386 
