### PR TITLE
out-of-band (oob) implemented for OAuth1.0

### DIFF
--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -13,13 +13,20 @@
 #' @keywords internal
 init_oauth1.0 <- function(endpoint, app, permission = NULL,
                           is_interactive = interactive(),
-                          private_key = NULL) {
+                          private_key = NULL, use_oob = getOption("httr_oob_default")) {
 
+  if (isTRUE(use_oob)) {
+    stopifnot(interactive())
+    redirect_uri <- "oob"
+  } else {
+    redirect_uri <- oauth_callback()
+  }
+  
   oauth_sig <- function(url, method, token = NULL, token_secret = NULL, private_key = NULL, ...) {
     oauth_header(oauth_signature(url, method, app, token, token_secret, private_key,
-        other_params = c(list(...), oauth_callback = oauth_callback())))
+        other_params = c(list(...), oauth_callback = redirect_uri)))
   }
-
+  
   # 1. Get an unauthorized request token
   response <- POST(endpoint$request, oauth_sig(endpoint$request, "POST", private_key = private_key))
   stop_for_status(response)

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -38,7 +38,14 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
   authorize_url <- modify_url(endpoint$authorize, query = list(
     oauth_token = token,
     permission = "read"))
-  verifier <- oauth_listener(authorize_url, is_interactive)
+  
+  if (isTRUE(use_oob)) {
+    verifier <- oauth_exchanger(authorize_url)
+  } else {
+    verifier <- oauth_listener(authorize_url, is_interactive)
+  }
+  
+  #verifier <- oauth_listener(authorize_url, is_interactive)
   verifier <- verifier$oauth_verifier %||% verifier[[1]]
 
   # 3. Request access token

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -141,8 +141,8 @@ Token <- R6::R6Class("Token", list(
 oauth1.0_token <- function(endpoint, app, permission = NULL,
                            as_header = TRUE,
                            private_key = NULL,
-                           cache = getOption("httr_oauth_cache")) {
-  params <- list(permission = permission, as_header = as_header)
+                           cache = getOption("httr_oauth_cache"), use_oob = getOption("httr_oob_default")) {
+  params <- list(permission = permission, as_header = as_header, use_oob = use_oob)
 
   Token1.0$new(app = app, endpoint = endpoint, params = params,
     private_key = private_key, cache_path = cache)
@@ -153,7 +153,7 @@ oauth1.0_token <- function(endpoint, app, permission = NULL,
 Token1.0 <- R6::R6Class("Token1.0", inherit = Token, list(
   init_credentials = function(force = FALSE) {
     self$credentials <- init_oauth1.0(self$endpoint, self$app,
-      permission = self$params$permission, private_key = self$private_key)
+      permission = self$params$permission, private_key = self$private_key, use_oob = self$params$use_oob)
   },
   can_refresh = function() {
     FALSE


### PR DESCRIPTION
oob was only implemented for OAuth2.0, but the specification of OAuth1.0 also stipulates it for OAuth1.0. See: 
https://oauth.net/core/1.0a/
