### PR TITLE
fix oauth_encode()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   callback functions that are called right before and after performing an
   HTTP request (@gaborcsardi #409)
 
+* Fix bug for OAuth 1 process: `oauth_encode()` now handles UTF-8 characters correctly.
+  (@yutannihilation #424)
+
 # httr 1.2.1
 
 * Fix bug with new cache creation code: need to check that 

--- a/R/oauth-signature.r
+++ b/R/oauth-signature.r
@@ -94,7 +94,7 @@ oauth_encode <- function(x) vapply(x, oauth_encode1, character(1))
 
 # As described in http://tools.ietf.org/html/rfc5849#page-29
 oauth_encode1 <- function(x) {
-  encode <- function(x) paste0("%", toupper(as.character(charToRaw(x))))
+  encode <- function(x) paste0("%", toupper(as.character(charToRaw(x))), collapse = "")
 
   x <- as.character(x)
   chars <- strsplit(x, "")[[1]]

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -44,3 +44,14 @@ test_that("partial OAuth1 flow works", {
   expect_equal(status_code(r), 200)
 })
 
+test_that("oauth_encode1 works", {
+  # chinese characters for "xaringan"
+  orig_string <- "\u5199\u8f6e\u773c"
+  restored_string <- URLdecode(oauth_encode1(orig_string))
+  Encoding(restored_string) <- "UTF-8"
+
+  expect_equal(
+    orig_string,
+    restored_string
+  )
+})

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -50,8 +50,5 @@ test_that("oauth_encode1 works", {
   restored_string <- URLdecode(oauth_encode1(orig_string))
   Encoding(restored_string) <- "UTF-8"
 
-  expect_equal(
-    orig_string,
-    restored_string
-  )
+  expect_equal(orig_string, restored_string)
 })


### PR DESCRIPTION
This PR fixes #423.

The problem is in [this part](https://github.com/hadley/httr/blob/1fc659856602f60ff75eb01903513244e3491ec2/R/oauth-signature.r#L97) of `oauth_encode1()`:

```r
 encode <- function(x) paste0("%", toupper(as.character(charToRaw(x))))
```

This seems to expect the result of `charToRaw(x)` is a single character, but this assumption fails when `x` is a UTF-8 character:

```r
paste0(charToRaw("あ"))
[1] "82" "a0"
```

Therefore, [the following line](https://github.com/hadley/httr/blob/1fc659856602f60ff75eb01903513244e3491ec2/R/oauth-signature.r#L105) doesn't work well:

```r
 chars[!ok] <- unlist(lapply(chars[!ok], encode))
```

As the length of the left hand side is smaller than the right hand side, some bytes at the tail is lost when assigning. That's what this warning says.

```r
httr:::oauth_encode1("写輪眼")
#> [1] "写\x97"
#> Warning message:
#> In chars[!ok] <- unlist(lapply(chars[!ok], encode)) :
#>   number of items to replace is not a multiple of replacement length
```

This pull request adds `collapse = ""` so that `encode()` returns a single character vector.

