### PR TITLE
OAuth 1.0 normalized URL must exclude default port

### DIFF
--- a/R/oauth-signature.r
+++ b/R/oauth-signature.r
@@ -49,6 +49,13 @@ oauth_signature <- function(url, method = "GET", app, token = NULL,
   method <- toupper(method)
 
   url <- parse_url(url)
+  if (!is.null(url$port)) {
+    if (url$scheme == "http" && url$port == "80") {
+      url$port <- NULL
+    } else if (url$scheme == "https" && url$port == "443") {
+      url$port <- NULL
+    }
+  }
   base_url <- build_url(url[c("scheme", "hostname", "port", "url", "path")])
 
   oauth <- compact(list(


### PR DESCRIPTION
There is a bug in `oauth_signature()` related to port handling. The [OAuth 1.0 spec](https://oauth.net/core/1.0/#anchor14) indicates:

> Unless specified, URL scheme and authority MUST be lowercase and include the port number; http default port 80 and https default port 443 MUST be excluded.

In other words, if port is specified as 80 for HTTP or 443 or HTTPS, the port number needs to be excluded from the normalized URL that is used in the OAuth 1.0 signature. `oauth_signature()` currently always includes the port number even if it is the default port number.

This PR fixes that.