### PR TITLE
Enable custom cert locations for non windows platforms

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -70,9 +70,6 @@ keep_last <- function(...) {
 }
 
 find_cert_bundle <- function() {
-  if (.Platform$OS.type != "windows")
-    return()
-
   env <- Sys.getenv("CURL_CA_BUNDLE")
   if (!identical(env, ""))
     return(env)


### PR DESCRIPTION
Not sure why the initial restriction for windows platforms. Setting the CURL_CA_BUNDLE from an environment variable comes in very handy in linux as well.