### PR TITLE
Don't form empty queries; closes #451

### DIFF
--- a/R/url.r
+++ b/R/url.r
@@ -161,5 +161,3 @@ modify_url <- function(url, scheme = NULL, hostname = NULL, port = NULL,
 
   build_url(utils::modifyList(old, new))
 }
-
-compact <- function(x) Filter(Negate(is.null), x)

--- a/R/url.r
+++ b/R/url.r
@@ -120,11 +120,11 @@ build_url <- function(url) {
   }
 
   if (is.list(url$query)) {
-    query <- compose_query(url$query)
+    query <- compose_query(compact(url$query))
   } else {
     query <- url$query
   }
-  if (!is.null(query)) {
+  if (!is.null(query) && nzchar(query)) {
     stopifnot(is.character(query), length(query) == 1)
     query <- paste0("?", query)
   }

--- a/R/utils.r
+++ b/R/utils.r
@@ -47,9 +47,11 @@ last <- function(x) {
 }
 
 compact <- function(x) {
-  null <- vapply(x, is.null, logical(1))
-  x[!null]
+  empty <- vapply(x, is_empty, logical(1))
+  x[!empty]
 }
+
+is_empty <- function(x) length(x) == 0
 
 keep_last <- function(...) {
   x <- c(...)

--- a/tests/testthat/test-url.r
+++ b/tests/testthat/test-url.r
@@ -66,10 +66,13 @@ test_that("build_url drops leading / in path", {
   expect_equal(url, "http://google.com/one")
 })
 
-test_that("build_url drops null query", {
+test_that("build_url drops null or empty query", {
   url <- modify_url("http://google.com", query = list(a = 1, b = NULL))
   expect_equal(url, "http://google.com/?a=1")
-
+  url <- modify_url("http://google.com", query = list(a = NULL))
+  expect_equal(url, "http://google.com/")
+  url <- modify_url("http://google.com", query = list())
+  expect_equal(url, "http://google.com/")
 })
 
 test_that("parse_url pulls off domain correctly given query without trailing '/'", {


### PR DESCRIPTION
See #451 

Before:

``` r
library(httr)
modify_url("http://google.com", query = list(a = NULL))
#> [1] "http://google.com/?="
modify_url("http://google.com", query = list())
#> [1] "http://google.com/?"
```

After:

``` r
devtools::load_all()
#> Loading httr
modify_url("http://google.com", query = list(a = NULL))
#> [1] "http://google.com/"
modify_url("http://google.com", query = list())
#> [1] "http://google.com/"
```