### PR TITLE
Fix overly sensitive unit test (error messages might fluctuate)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ r:
   - release
   - devel
 
+r_github_packages:
+  - jeroen/curl
+
 env:
   global:
     secure: Jhp65lhvVcvDzPmn56M/SFrREG6xPMbAH64m5q7qBt67ns8edO87xdhG+O3U5f6LFlWs4I8vkC4Ruo2XCEEnwo23lEPR+/u3fLEKC8KIYXwFyKXIrLxANKLxUF3LmxYAYGXQiJw+W6pPdDIHxlOZeE+qyuwQ67LjnuA5egGsc1Y=

--- a/tests/testthat/test-config.r
+++ b/tests/testthat/test-config.r
@@ -32,6 +32,6 @@ test_that("digest authentication works", {
 test_that("timeout enforced", {
   skip_on_cran()
   expect_error(GET("http://httpbin.org/delay/1", timeout(0.5)),
-    "Timeout was reached")
+    "(Timeout was reached)|(timed out)")
 })
 


### PR DESCRIPTION
The new version of `curl` has some more detailed error messages with slightly different wording.