### PR TITLE
Improvements to RETRY (#404)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # httr 1.2.1.9000
 
+* `RETRY()` gains a new parameter `terminate_on` that giver caller greater control
+  on which status codes make it stop retrying, and also now retries if an
+  error condition (i.e., a call to `stop()`) occurs during the request (@asieira #404)
+
 * Fix bug with cert bundle lookup: `find_cert_bundle()` will now return cert bundle
   in "R_HOME/etc" (@jiwalker-usgs #386).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # httr 1.2.1.9000
 
-* `RETRY()` gains a new parameter `terminate_on` that giver caller greater control
-  on which status codes make it stop retrying, and also now retries if an
+* `RETRY()` gains a new parameter `terminate_on` that gives caller greater control
+  over which status codes make it stop retrying, and also now retries if an
   error condition (i.e., a call to `stop()`) occurs during the request (@asieira #404)
 
 * Fix bug with cert bundle lookup: `find_cert_bundle()` will now return cert bundle

--- a/R/retry.R
+++ b/R/retry.R
@@ -81,11 +81,13 @@ backoff_full_jitter <- function(i, resp, pause_base = 1, pause_cap = 60, quiet =
   length <- ceiling(stats::runif(1, max = min(pause_cap, pause_base * (2 ^ i))))
   if (!quiet) {
     if (inherits(resp, "error")) {
-      error_description <- gsub("[\n\r]+$", "", as.character(resp))
-      message(error_description, "\nRequest failed [ERROR]. Retrying in ", length, " seconds...")
+      error_description <- gsub("[\n\r]*$", "\n", as.character(resp))
+      status <- "ERROR"
     } else {
-      message("Request failed [", status_code(resp), "]. Retrying in ", length, " seconds...")
+      error_description <- ""
+      status <- status_code(resp)
     }
+    message(error_description, "Request failed [", status, "]. Retrying in ", length, " seconds...")
   }
   Sys.sleep(length)
 }

--- a/R/retry.R
+++ b/R/retry.R
@@ -80,8 +80,12 @@ retry_should_terminate <- function(i, times, resp, terminate_on) {
 backoff_full_jitter <- function(i, resp, pause_base = 1, pause_cap = 60, quiet = FALSE) {
   length <- ceiling(stats::runif(1, max = min(pause_cap, pause_base * (2 ^ i))))
   if (!quiet) {
-    status <- if (inherits(resp, "error")) as.character(resp) else status_code(resp)
-    message("Request failed [", status, "]. Retrying in ", length, " seconds...")
+    if (inherits(resp, "error")) {
+      error_description <- gsub("[\n\r]+$", "", as.character(resp))
+      message(error_description, "\nRequest failed [ERROR]. Retrying in ", length, " seconds...")
+    } else {
+      message("Request failed [", status_code(resp), "]. Retrying in ", length, " seconds...")
+    }
   }
   Sys.sleep(length)
 }

--- a/R/retry.R
+++ b/R/retry.R
@@ -21,7 +21,7 @@
 #' @param quiet If \code{FALSE}, will print a message displaying how long
 #'   until the next request.
 #' @param terminate_on Optional vector of numeric HTTP status codes that if found
-#'   on the response will immediately stop the retries. If missing or NULL, will
+#'   on the response will terminate the retry process. If missing or NULL, will
 #'   keep retrying while \code{\link{http_error}()} is \code{TRUE} for the response.
 #' @return The last response. Note that if the request doesn't succeed after
 #'   \code{times} times this will be a failed request, i.e. you still need

--- a/R/retry.R
+++ b/R/retry.R
@@ -79,7 +79,7 @@ retry_should_stop <- function(i, times, resp, terminate_on) {
 backoff_full_jitter <- function(i, resp, pause_base = 1, pause_cap = 60, quiet = FALSE) {
   length <- ceiling(stats::runif(1, max = min(pause_cap, pause_base * (2 ^ i))))
   if (!quiet) {
-    status = if ("error" %in% class(resp)) as.character(resp) else status_code(resp)
+    status <- if ("error" %in% class(resp)) as.character(resp) else status_code(resp)
     message("Request failed [", status, "]. Retrying in ", length, " seconds...")
   }
   Sys.sleep(length)

--- a/R/retry.R
+++ b/R/retry.R
@@ -74,7 +74,7 @@ retry_should_stop <- function(i, times, resp, terminate_on) {
   } else if (!is.null(terminate_on)) {
     return(status_code(resp) %in% terminate_on)
   } else {
-    return(http_error(resp))
+    return(!http_error(resp))
   }
 }
 

--- a/R/retry.R
+++ b/R/retry.R
@@ -21,8 +21,8 @@
 #' @param quiet If \code{FALSE}, will print a message displaying how long
 #'   until the next request.
 #' @param terminate_on Optional vector of numeric HTTP status codes that if found
-#'   on the response will terminate the retry process. If missing or NULL, will
-#'   keep retrying while \code{\link{http_error}()} is \code{TRUE} for the response.
+#'   on the response will terminate the retry process. If \code{NULL}, will keep
+#'   retrying while \code{\link{http_error}()} is \code{TRUE} for the response.
 #' @return The last response. Note that if the request doesn't succeed after
 #'   \code{times} times this will be a failed request, i.e. you still need
 #'   to use \code{\link{stop_for_status}()}.

--- a/R/retry.R
+++ b/R/retry.R
@@ -4,7 +4,7 @@
 #' parameter, which by default means a response for which \code{\link{http_error}()}
 #' is \code{FALSE}. Will also retry on error conditions raised by the underlying curl code,
 #' but if the last retry still raises one, \code{RETRY} will raise it again with
-#' \code{\link{stop}()} to maintain backwards compatibility.
+#' \code{\link{stop}()}.
 #' It is designed to be kind to the server: after each failure
 #' randomly waits up to twice as long. (Technically it uses exponential
 #' backoff with jitter, using the approach outlined in

--- a/R/retry.R
+++ b/R/retry.R
@@ -33,9 +33,11 @@
 #' RETRY("GET", "http://httpbin.org/status/200")
 #' # Never succeeds
 #' RETRY("GET", "http://httpbin.org/status/500")
+#' \donttest{
 #' # Invalid hostname generates curl error condition and is retried but eventually
 #' # raises an error condition.
 #' RETRY("GET", "http://invalidhostname/")
+#' }
 RETRY <- function(verb, url = NULL, config = list(), ...,
                   body = NULL, encode = c("multipart", "form", "json", "raw"),
                   times = 3, pause_base = 1, pause_cap = 60,

--- a/R/retry.R
+++ b/R/retry.R
@@ -44,7 +44,7 @@ RETRY <- function(verb, url = NULL, config = list(), ...,
   stopifnot(is.numeric(times), length(times) == 1L)
   stopifnot(is.numeric(pause_base), length(pause_base) == 1L)
   stopifnot(is.numeric(pause_cap), length(pause_cap) == 1L)
-  stopifnot(is.integer(terminate_on) || is.numeric(terminate_on) || is.null(terminate_on))
+  stopifnot(is.numeric(terminate_on) || is.null(terminate_on))
 
   hu <- handle_url(handle, url, ...)
   req <- request_build(verb, hu$url, body_config(body, match.arg(encode)), config, ...)

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -6,7 +6,8 @@
 \usage{
 RETRY(verb, url = NULL, config = list(), ..., body = NULL,
   encode = c("multipart", "form", "json", "raw"), times = 3,
-  pause_base = 1, pause_cap = 60, handle = NULL, quiet = FALSE)
+  pause_base = 1, pause_cap = 60, handle = NULL, quiet = FALSE,
+  terminate_on = NULL)
 }
 \arguments{
 \item{verb}{Name of verb to use.}
@@ -67,6 +68,11 @@ details.}
 
 \item{quiet}{If \code{FALSE}, will print a message displaying how long
 until the next request.}
+
+\item{terminate_on}{Optional vector of numeric or integer HTTP status codes
+that if found on the response will immediately stop the retries. If missing
+or NULL, will keep retrying while \code{\link{http_error}()} is \code{TRUE}
+for the response.}
 }
 \value{
 The last response. Note that if the request doesn't succeed after
@@ -74,8 +80,10 @@ The last response. Note that if the request doesn't succeed after
   to use \code{\link{stop_for_status}()}.
 }
 \description{
-Safely retry a request until it succeeds (returns an HTTP status code
-below 400). It is designed to be kind to the server: after each failure
+Safely retry a request until it succeeds, as defined by the \code{terminate_on}
+parameter, which by default means a response for which \code{\link{http_error}()}
+is \code{FALSE}. Will also retry on error conditions raised by the underlying curl code.
+It is designed to be kind to the server: after each failure
 randomly waits up to twice as long. (Technically it uses exponential
 backoff with jitter, using the approach outlined in
 \url{https://www.awsarchitectureblog.com/2015/03/backoff.html}.)
@@ -85,4 +93,6 @@ backoff with jitter, using the approach outlined in
 RETRY("GET", "http://httpbin.org/status/200")
 # Never succeeds
 RETRY("GET", "http://httpbin.org/status/500")
+# Invalid hostname generates curl error condition and is retried
+RETRY("GET", "http://invalidhostname/")
 }

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -83,7 +83,7 @@ Safely retry a request until it succeeds, as defined by the \code{terminate_on}
 parameter, which by default means a response for which \code{\link{http_error}()}
 is \code{FALSE}. Will also retry on error conditions raised by the underlying curl code,
 but if the last retry still raises one, \code{RETRY} will raise it again with
-\code{\link{stop}()} to maintain backwards compatibility.
+\code{\link{stop}()}.
 It is designed to be kind to the server: after each failure
 randomly waits up to twice as long. (Technically it uses exponential
 backoff with jitter, using the approach outlined in

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -69,10 +69,9 @@ details.}
 \item{quiet}{If \code{FALSE}, will print a message displaying how long
 until the next request.}
 
-\item{terminate_on}{Optional vector of numeric or integer HTTP status codes
-that if found on the response will immediately stop the retries. If missing
-or NULL, will keep retrying while \code{\link{http_error}()} is \code{TRUE}
-for the response.}
+\item{terminate_on}{Optional vector of numeric HTTP status codes that if found
+on the response will terminate the retry process. If missing or NULL, will
+keep retrying while \code{\link{http_error}()} is \code{TRUE} for the response.}
 }
 \value{
 The last response. Note that if the request doesn't succeed after

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -82,7 +82,9 @@ The last response. Note that if the request doesn't succeed after
 \description{
 Safely retry a request until it succeeds, as defined by the \code{terminate_on}
 parameter, which by default means a response for which \code{\link{http_error}()}
-is \code{FALSE}. Will also retry on error conditions raised by the underlying curl code.
+is \code{FALSE}. Will also retry on error conditions raised by the underlying curl code,
+but if the last retry still raises one, \code{RETRY} will raise it again with
+\code{\link{stop}()} to maintain backwards compatibility.
 It is designed to be kind to the server: after each failure
 randomly waits up to twice as long. (Technically it uses exponential
 backoff with jitter, using the approach outlined in
@@ -93,6 +95,9 @@ backoff with jitter, using the approach outlined in
 RETRY("GET", "http://httpbin.org/status/200")
 # Never succeeds
 RETRY("GET", "http://httpbin.org/status/500")
-# Invalid hostname generates curl error condition and is retried
+\donttest{
+# Invalid hostname generates curl error condition and is retried but eventually
+# raises an error condition.
 RETRY("GET", "http://invalidhostname/")
+}
 }

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -70,8 +70,8 @@ details.}
 until the next request.}
 
 \item{terminate_on}{Optional vector of numeric HTTP status codes that if found
-on the response will terminate the retry process. If missing or NULL, will
-keep retrying while \code{\link{http_error}()} is \code{TRUE} for the response.}
+on the response will terminate the retry process. If \code{NULL}, will keep
+retrying while \code{\link{http_error}()} is \code{TRUE} for the response.}
 }
 \value{
 The last response. Note that if the request doesn't succeed after


### PR DESCRIPTION
* Add new `terminate_on` parameter that allows status_codes that
prevent retries to be specified;
* Catch error conditions using `tryCatch` and retry if they occur.