### PR TITLE
Client credential v2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # httr 1.2.1.9000
 
+* `init_oauth2.0()` gains `client_credentials`, defaulting to `FALSE`, which 
+  allows you to use Oauth2 dance with some APIs (e.g yelp) that required 
+  *Client Credential Grant* instead of *Authorization Code Grant* for 
+  obtaining authorization. See [RFC 6749](https://tools.ietf.org/html/rfc6749#section-4).
+  (@cderv, #384)
+
 * Added `pause_min` to `RETRY` requests, allowing for sub-second
   delays. (Use with caution! Generally the default is preferred.) (@r2evans)
 

--- a/R/oauth-endpoint.r
+++ b/R/oauth-endpoint.r
@@ -5,7 +5,7 @@
 #'
 #' @param request url used to request initial (unauthenticated) token.
 #'   If using OAuth2.0, leave as \code{NULL}.
-#' @param authorize url to send client to for authorisation. Set as \code{NULL}
+#' @param authorize url to send client to for authorisation. Set to \code{NULL}
 #'   if not needed
 #' @param access url used to exchange unauthenticated for authenticated token.
 #' @param ... other additional endpoints.

--- a/R/oauth-endpoint.r
+++ b/R/oauth-endpoint.r
@@ -5,7 +5,8 @@
 #'
 #' @param request url used to request initial (unauthenticated) token.
 #'   If using OAuth2.0, leave as \code{NULL}.
-#' @param authorize url to send client to for authorisation
+#' @param authorize url to send client to for authorisation. Set as \code{NULL}
+#'   if not needed
 #' @param access url used to exchange unauthenticated for authenticated token.
 #' @param ... other additional endpoints.
 #' @param base_url option url to use as base for \code{request},

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -64,7 +64,7 @@ init_oauth1.0 <- function(endpoint, app, permission = NULL,
 #'     app key and secret in the request body.
 #' @param config_init Additional configuration settings sent to
 #'     \code{\link{POST}}, e.g. \code{\link{user_agent}}.
-#' @param client_credentials default to \code{FALSE}. Set to \code{TRUE} to use
+#' @param client_credentials Default to \code{FALSE}. Set to \code{TRUE} to use
 #'   \emph{Client Credentials Grant} instead of \emph{Authorization
 #'   Code Grant}. See \url{https://tools.ietf.org/html/rfc6749#section-4.4}.
 #' @export

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -88,15 +88,19 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
 
   # Some Oauth2 grant type not required an authorization request and code
   # (see https://tools.ietf.org/html/rfc6749#section-4.4)
-  if(client_credentials) {
+  if (client_credentials) {
     code <- NULL
   } else {
-    authorize_url <- modify_url(endpoint$authorize, query = compact(list(
-      client_id = app$key,
-      scope = scope_arg,
-      redirect_uri = redirect_uri,
-      response_type = "code",
-      state = state)))
+    authorize_url <- modify_url(
+      url = endpoint$authorize,
+      query = compact(list(
+        client_id = app$key,
+        scope = scope_arg,
+        redirect_uri = redirect_uri,
+        response_type = "code",
+        state = state)
+      )
+    )
 
     if (use_oob) {
       code <- oauth_exchanger(authorize_url)$code

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -113,12 +113,12 @@ init_oauth2.0 <- function(endpoint, app, scope = NULL, user_params = NULL,
   # Send credentials using HTTP Basic or as parameters in the request body
   # See https://tools.ietf.org/html/rfc6749#section-2.3 (Client Authentication)
 
-  req_params <- list(
+  req_params <- compact(list(
     client_id = app$key,
     redirect_uri = if (client_credentials) NULL else redirect_uri,
     grant_type = if (client_credentials) "client_credentials" else "authorization_code",
     code = code
-  )
+  ))
 
   if (!is.null(user_params)) {
     req_params <- utils::modifyList(user_params, req_params)

--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -198,11 +198,13 @@ oauth2.0_token <- function(endpoint, app, scope = NULL, user_params = NULL,
                            as_header = TRUE,
                            use_basic_auth = FALSE,
                            cache = getOption("httr_oauth_cache"),
-                           config_init = list()) {
+                           config_init = list(),
+                           client_credentials = FALSE) {
   params <- list(scope = scope, user_params = user_params, type = type,
       use_oob = use_oob, as_header = as_header,
       use_basic_auth = use_basic_auth,
-      config_init = config_init)
+      config_init = config_init,
+      client_credentials = client_credentials)
 
   Token2.0$new(app = app, endpoint = endpoint, params = params,
     cache_path = cache)
@@ -216,7 +218,8 @@ Token2.0 <- R6::R6Class("Token2.0", inherit = Token, list(
       scope = self$params$scope, user_params = self$params$user_params,
       type = self$params$type, use_oob = self$params$use_oob,
       use_basic_auth = self$params$use_basic_auth,
-      config_init = self$params$config_init)
+      config_init = self$params$config_init,
+      client_credentials = self$params$client_credentials)
   },
   can_refresh = function() {
     !is.null(self$credentials$refresh_token)

--- a/demo/00Index
+++ b/demo/00Index
@@ -9,4 +9,5 @@ oauth2-github       Using the github api with OAuth 2.0
 oauth2-google       Using the google api with OAuth 2.0
 oauth2-reddit       Using the reddit api with OAuth 2.0
 oauth2-linkedin     Using linkedin api with OAuth 1.0
+oauth2-yelp         Using yelp api with OAuth 2.0 and Client Credentials Grant
 service-account     Using Google service account

--- a/demo/oauth2-yelp.R
+++ b/demo/oauth2-yelp.R
@@ -31,9 +31,11 @@ yelp_token <- oauth2.0_token(
 url <- modify_url(
   url = "https://api.yelp.com",
   path = c("v3", "businesses", "search"),
-  query = list(term = "coffee",
-               location = "Vancouver, BC",
-               limit = 3)
+  query = list(
+    term = "coffee",
+    location = "Vancouver, BC",
+    limit = 3
+  )
 )
 
 req <- GET(url, config(token = token))

--- a/demo/oauth2-yelp.R
+++ b/demo/oauth2-yelp.R
@@ -1,0 +1,31 @@
+library(httr)
+
+# This example demonstrates the use of client credentials grant
+
+# 1. Find OAuth settings for yelp:
+#    https://www.yelp.ca/developers/documentation/v3/authentication
+#    Set authorize url to NULL as we are not using Authorization code grant but
+#    client credential grant
+yelp_endpoint <- oauth_endpoint(
+  authorize = NULL,
+  access    = "https://api.yelp.com/oauth2/token"
+)
+
+# 2. Register an application at https://www.yelp.com/developers/v3/manage_app
+#    Replace key and secret below.
+yelp_app <- oauth_app("yelp", "bvmjj2EOBvOknQ", "n8ueSvTNdlE0BDDJpLljvmgUGUw")
+
+# 3. Get OAuth credentials using client credential grant
+#    Yelp do not use basic auth. Use `use_basic_auth = T` otherwise
+yelp_token <- oauth2.0_token(yelp_endpoint, yelp_app,
+                        client_credentials = T)
+
+# 4. Use API
+url <- modify_url("https://api.yelp.com",
+                  path = c("v3", "businesses", "search"),
+                  query = list(term = "coffee",
+                               location = "Vancouver, BC",
+                               limit = 3))
+req <- GET(url, config(token = token))
+stop_for_status(req)
+content(req)

--- a/demo/oauth2-yelp.R
+++ b/demo/oauth2-yelp.R
@@ -1,11 +1,11 @@
 library(httr)
 
-# This example demonstrates the use of client credentials grant
+# This example demonstrate the use of client credentials grant
 
 # 1. Find OAuth settings for yelp:
-#    https://www.yelp.ca/developers/documentation/v3/authentication
-#    Set authorize url to NULL as we are not using Authorization code grant but
-#    client credential grant
+# https://www.yelp.ca/developers/documentation/v3/authentication
+# Set authorize url to NULL as we are not using Authorization code grant
+# but client credential grant
 yelp_endpoint <- oauth_endpoint(
   authorize = NULL,
   access    = "https://api.yelp.com/oauth2/token"
@@ -13,19 +13,29 @@ yelp_endpoint <- oauth_endpoint(
 
 # 2. Register an application at https://www.yelp.com/developers/v3/manage_app
 #    Replace key and secret below.
-yelp_app <- oauth_app("yelp", "bvmjj2EOBvOknQ", "n8ueSvTNdlE0BDDJpLljvmgUGUw")
+yelp_app <- oauth_app(
+  appname = "yelp",
+  key = "bvmjj2EOBvOknQ",
+  secret = "n8ueSvTNdlE0BDDJpLljvmgUGUw"
+)
 
 # 3. Get OAuth credentials using client credential grant
 #    Yelp do not use basic auth. Use `use_basic_auth = T` otherwise
-yelp_token <- oauth2.0_token(yelp_endpoint, yelp_app,
-                        client_credentials = T)
+yelp_token <- oauth2.0_token(
+  endpoint = yelp_endpoint,
+  app = yelp_app,
+  client_credentials = T
+)
 
 # 4. Use API
-url <- modify_url("https://api.yelp.com",
-                  path = c("v3", "businesses", "search"),
-                  query = list(term = "coffee",
-                               location = "Vancouver, BC",
-                               limit = 3))
+url <- modify_url(
+  url = "https://api.yelp.com",
+  path = c("v3", "businesses", "search"),
+  query = list(term = "coffee",
+               location = "Vancouver, BC",
+               limit = 3)
+)
+
 req <- GET(url, config(token = token))
 stop_for_status(req)
 content(req)

--- a/man/init_oauth2.0.Rd
+++ b/man/init_oauth2.0.Rd
@@ -38,7 +38,7 @@ app key and secret in the request body.}
 \item{config_init}{Additional configuration settings sent to
 \code{\link{POST}}, e.g. \code{\link{user_agent}}.}
 
-\item{client_credentials}{default to \code{FALSE}. Set to \code{TRUE} to use
+\item{client_credentials}{Default to \code{FALSE}. Set to \code{TRUE} to use
 \emph{Client Credentials Grant} instead of \emph{Authorization
 Code Grant}. See \url{https://tools.ietf.org/html/rfc6749#section-4.4}.}
 }

--- a/man/init_oauth2.0.Rd
+++ b/man/init_oauth2.0.Rd
@@ -7,7 +7,7 @@
 init_oauth2.0(endpoint, app, scope = NULL, user_params = NULL,
   type = NULL, use_oob = getOption("httr_oob_default"),
   is_interactive = interactive(), use_basic_auth = FALSE,
-  config_init = list())
+  config_init = list(), client_credentials = FALSE)
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -37,6 +37,10 @@ app key and secret in the request body.}
 
 \item{config_init}{Additional configuration settings sent to
 \code{\link{POST}}, e.g. \code{\link{user_agent}}.}
+
+\item{client_credentials}{default to \code{FALSE}. Set to \code{TRUE} to use
+\emph{Client Credentials Grant} instead of \emph{Authorization
+Code Grant}. See \url{https://tools.ietf.org/html/rfc6749#section-4.4}.}
 }
 \description{
 See demos for use.

--- a/man/oauth2.0_token.Rd
+++ b/man/oauth2.0_token.Rd
@@ -7,7 +7,7 @@
 oauth2.0_token(endpoint, app, scope = NULL, user_params = NULL,
   type = NULL, use_oob = getOption("httr_oob_default"), as_header = TRUE,
   use_basic_auth = FALSE, cache = getOption("httr_oauth_cache"),
-  config_init = list())
+  config_init = list(), client_credentials = FALSE)
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -45,6 +45,10 @@ A string mean use the specified path as the cache file.}
 
 \item{config_init}{Additional configuration settings sent to
 \code{\link{POST}}, e.g. \code{\link{user_agent}}.}
+
+\item{client_credentials}{default to \code{FALSE}. Set to \code{TRUE} to use
+\emph{Client Credentials Grant} instead of \emph{Authorization
+Code Grant}. See \url{https://tools.ietf.org/html/rfc6749#section-4.4}.}
 }
 \value{
 A \code{Token2.0} reference class (RC) object.

--- a/man/oauth2.0_token.Rd
+++ b/man/oauth2.0_token.Rd
@@ -46,7 +46,7 @@ A string mean use the specified path as the cache file.}
 \item{config_init}{Additional configuration settings sent to
 \code{\link{POST}}, e.g. \code{\link{user_agent}}.}
 
-\item{client_credentials}{default to \code{FALSE}. Set to \code{TRUE} to use
+\item{client_credentials}{Default to \code{FALSE}. Set to \code{TRUE} to use
 \emph{Client Credentials Grant} instead of \emph{Authorization
 Code Grant}. See \url{https://tools.ietf.org/html/rfc6749#section-4.4}.}
 }

--- a/man/oauth_endpoint.Rd
+++ b/man/oauth_endpoint.Rd
@@ -10,7 +10,8 @@ oauth_endpoint(request = NULL, authorize, access, ..., base_url = NULL)
 \item{request}{url used to request initial (unauthenticated) token.
 If using OAuth2.0, leave as \code{NULL}.}
 
-\item{authorize}{url to send client to for authorisation}
+\item{authorize}{url to send client to for authorisation. Set as \code{NULL}
+if not needed}
 
 \item{access}{url used to exchange unauthenticated for authenticated token.}
 

--- a/man/oauth_endpoint.Rd
+++ b/man/oauth_endpoint.Rd
@@ -10,7 +10,7 @@ oauth_endpoint(request = NULL, authorize, access, ..., base_url = NULL)
 \item{request}{url used to request initial (unauthenticated) token.
 If using OAuth2.0, leave as \code{NULL}.}
 
-\item{authorize}{url to send client to for authorisation. Set as \code{NULL}
+\item{authorize}{url to send client to for authorisation. Set to \code{NULL}
 if not needed}
 
 \item{access}{url used to exchange unauthenticated for authenticated token.}


### PR DESCRIPTION
This is the new PR following #388 discussion. It closes #384. 

+ Uses `client_credentials = TRUE` to activate use of client credential grant
+ Sets `code <- NULL`, `redirect_uri` to NULL (as not need for this grant) and set `grant_type ="client_credentials"` 
+ Tweaks documentation of `oauth_endpoint` for authorize url
+ Adds a demo file for YELP API to demonstrate the use of an API with client credential grant.
+ Adds a bullet to NEWS

I also generate new documentation. 

@hadley , what do you think of this new PR ? 