### PR TITLE
fix client credentials grant

### DIFF
--- a/R/oauth-token.r
+++ b/R/oauth-token.r
@@ -221,7 +221,8 @@ oauth2.0_token <- function(endpoint, app, scope = NULL, user_params = NULL,
     use_oob = use_oob,
     as_header = as_header,
     use_basic_auth = use_basic_auth,
-    config_init = config_init
+    config_init = config_init,
+    client_credentials = client_credentials
   )
 
   Token2.0$new(


### PR DESCRIPTION
During resolution of merge conflict in #463, a line was lost. 

This PR is just there to add back this missing in order for #384 to work.

Sorry for that. When you resolve merge conflict directly on github, it is not easy to check. 

Will do this locally next time. 