### PR TITLE
minor changes/adds

### DIFF
--- a/vignettes/secrets.Rmd
+++ b/vignettes/secrets.Rmd
@@ -53,7 +53,16 @@ Working with secret files locally is straightforward because it's ok to store th
   so they don't accidentally get included in a public R package.
   
 httr proactively takes both of these steps for you whenever it creates a `.httr-oauth` file.
-  
+
+You should restrict access to secrets stored in local files by ensuring that only you can read them. You can use the R function `Sys.chmod()` to accomplish this:
+
+```{r}
+Sys.chmod("secret.file", mode = "0400")
+}
+```
+
+You should verify this setting by examinng the file metadata with your local filesystem GUI tools or commands.
+
 The main remaining risk is that you might zip up the entire directory and share it. If you're worried about this scenario, store your secret files outside of the project directory. If you do this, make sure to provide a helper function to locate the file and provide an informative message if it's missing.
 
 ```{r}
@@ -116,7 +125,7 @@ Sys.getenv("VAR1")
 
 Note that `.Renviron` is only processed on startup, so you'll need to restart R to see changes.
 
-These environment variables will be available in every running R process, and can easily be read by any other program on your computer to access that file directly. For more security, use the keyring package.
+These environment variables will be available in every running R process, and can easily be read by any other program on your computer to access that file directly. For more security, use the keyring package. 
 
 ### Keyring
 
@@ -179,7 +188,7 @@ encrypt <- function(secret, username) {
 
   resp <- httr::GET(url)
   httr::stop_for_status(resp)
-  pubkey <- content(resp)[[1]]$key
+  pubkey <- httr::content(resp)[[1]]$key
 
   opubkey <- openssl::read_pubkey(pubkey)
   cipher <- openssl::rsa_encrypt(charToRaw(secret), opubkey)
@@ -203,11 +212,11 @@ decrypt(cipher)
 #> password
 ```
 
-I'll use the credentials carefully and won't share them with anyone else, but I still recommend changing your password before and after you share it with me.
+Change your password before and after you share it with me or anyone else. 
 
 ### GitHub
 
-If you want to share secrets with a group of other people on GitHub, use the [secret](https://github.com/gaborcsardi/secret) package.
+If you want to share secrets with a group of other people on GitHub, use the [secret](https://github.com/gaborcsardi/secret) or [cyphr](https://github.com/richfitz/cyphr) packages.
 
 ### Travis
 


### PR DESCRIPTION
- 56-65 : Folks will likely either not know about or be thinking about file permissions, so this should work on macOS, Windows and Linux and is good practices in and out of multi-tenant environments
- 191 : `httr::content` for consistency
- 215 : Selective trust will give folks bad habits :-)
- 219 : You're likely trying to keep this simple for readers but `cyphr` does a ++gd job managing group secrets