### PR TITLE
Has re-added code for using value of "retry-after" header as waiting time if status_code = 429

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,10 @@
 * More forms of empty query are recognized as such. Eliminates a source of 
   spurious trailing `?` and `?=` in URLs produced by `modify_url()`. 
   (@jennybc, #452)
+  
+* If the server returns HTTP status code 429 and specifies a `retry-after` 
+  value, that value will now be used instead of exponential backoff with 
+  jitter, unless it's smaller than `pause_min`. (@nielsoledam, #472)
 
 # httr 1.2.1
 

--- a/R/retry.R
+++ b/R/retry.R
@@ -95,7 +95,9 @@ backoff_full_jitter <- function(i, resp, pause_base = 1, pause_cap = 60,
     }
     if (status == 429) {
       retry_after <- resp$headers[["retry-after"]]
-      if (!is.null(retry_after)) length <- max(pause_min, as.numeric(retry_after))
+      if (!is.null(retry_after)) {
+        length <- max(pause_min, as.numeric(retry_after))
+      }
     }
     message(error_description, "Request failed [", status, "]. Retrying in ", round(length, 1), " seconds...")
   }

--- a/R/retry.R
+++ b/R/retry.R
@@ -91,6 +91,10 @@ backoff_full_jitter <- function(i, resp, pause_base = 1, pause_cap = 60,
       error_description <- ""
       status <- status_code(resp)
     }
+    if (status == 429) {
+      length_429 <- as.numeric(resp$headers[["retry-after"]])
+      if (!is.null(length_429) && length_429 >= pause_min) length <- length_429
+    }
     message(error_description, "Request failed [", status, "]. Retrying in ", round(length, 1), " seconds...")
   }
   Sys.sleep(length)

--- a/R/retry.R
+++ b/R/retry.R
@@ -9,6 +9,8 @@
 #' randomly waits up to twice as long. (Technically it uses exponential
 #' backoff with jitter, using the approach outlined in
 #' \url{https://www.awsarchitectureblog.com/2015/03/backoff.html}.)
+#' If the server returns status code 429 and specifies a \code{retry-after} value, that
+#' value will be used instead, unless it's smaller than \code{pause_min}.
 #'
 #' @inheritParams VERB
 #' @inheritParams GET
@@ -92,8 +94,8 @@ backoff_full_jitter <- function(i, resp, pause_base = 1, pause_cap = 60,
       status <- status_code(resp)
     }
     if (status == 429) {
-      length_429 <- as.numeric(resp$headers[["retry-after"]])
-      if (!is.null(length_429) && length_429 >= pause_min) length <- length_429
+      retry_after <- resp$headers[["retry-after"]]
+      if (!is.null(retry_after)) length <- max(pause_min, as.numeric(retry_after))
     }
     message(error_description, "Request failed [", status, "]. Retrying in ", round(length, 1), " seconds...")
   }


### PR DESCRIPTION
I've reset my fork to the current master and re-added the code changes as discussed on https://github.com/r-lib/httr/pull/434.

The code now also respects  the value of pause_min.