### PR TITLE
Fix unnecessary error on failure to parse headers$Date

### DIFF
--- a/R/request.R
+++ b/R/request.R
@@ -147,9 +147,12 @@ request_perform <- function(req, handle, refresh = TRUE) {
 
   all_headers <- parse_headers(resp$headers)
   headers <- last(all_headers)$headers
+
   if (!is.null(headers$date)) {
     date <- parse_http_date(headers$Date)
-  } else {
+  }
+
+  if (is.null(headers$date) || is.na(date)) {
     date <- Sys.time()
   }
 


### PR DESCRIPTION
Hi,

when parsing the `headers$Date` in `request_perform` fails, e.g. because the response is not in `en_US` it results in an unhelpful prettyNum (or so) error.

I just split the if-else to replace the `date` with something valid if it failed to parse.

Ciao,
Stefan

