### PR TITLE
allow httr::POST to pass args to jsonlite::toJSON

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     covr
 VignetteBuilder: knitr
 License: MIT + file LICENSE
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 URL: https://github.com/r-lib/httr
 BugReports: https://github.com/r-lib/httr/issues
 Verison: 1.3.1.9000

--- a/R/body.R
+++ b/R/body.R
@@ -1,6 +1,6 @@
 body_config <- function(body = NULL,
                         encode = c("form", "json", "multipart", "raw"),
-                        type = NULL)  {
+                        type = NULL, ...)  {
   # No body
   if (identical(body, FALSE))
     return(config(post = TRUE, nobody = TRUE))
@@ -43,6 +43,7 @@ body_config <- function(body = NULL,
   }
 
   body <- compact(body)
+  args <- list(...)
 
   # Deal with three ways to encode: form, multipart & json
   encode <- match.arg(encode)
@@ -51,7 +52,8 @@ body_config <- function(body = NULL,
   } else if (encode == "form") {
     body_raw(compose_query(body), "application/x-www-form-urlencoded")
   } else if (encode == "json") {
-    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE), "application/json")
+    null <- ifelse(is.null(args$null), "list", args$null)
+    body_raw(jsonlite::toJSON(body, auto_unbox = TRUE, null = null), "application/json")
   } else if (encode == "multipart") {
     if (!all(has_name(body)))
       stop("All components of body must be named", call. = FALSE)

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -46,6 +46,7 @@ POST <- function(url = NULL, config = list(), ..., body = NULL,
   encode <- match.arg(encode)
 
   hu <- handle_url(handle, url, ...)
-  req <- request_build("POST", hu$url, body_config(body, match.arg(encode)), as.request(config), ...)
+  req <- request_build("POST", hu$url, body_config(body, match.arg(encode), ...),
+                       as.request(config), ...)
   request_perform(req, hu$handle$handle)
 }

--- a/man/BROWSE.Rd
+++ b/man/BROWSE.Rd
@@ -40,3 +40,4 @@ Other http methods: \code{\link{DELETE}},
   \code{\link{PATCH}}, \code{\link{POST}},
   \code{\link{PUT}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/DELETE.Rd
+++ b/man/DELETE.Rd
@@ -90,3 +90,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{PATCH}}, \code{\link{POST}},
   \code{\link{PUT}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/GET.Rd
+++ b/man/GET.Rd
@@ -80,3 +80,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{PATCH}}, \code{\link{POST}},
   \code{\link{PUT}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/HEAD.Rd
+++ b/man/HEAD.Rd
@@ -57,3 +57,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{PATCH}}, \code{\link{POST}},
   \code{\link{PUT}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/PATCH.Rd
+++ b/man/PATCH.Rd
@@ -64,3 +64,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{HEAD}}, \code{\link{POST}},
   \code{\link{PUT}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/POST.Rd
+++ b/man/POST.Rd
@@ -76,3 +76,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{HEAD}}, \code{\link{PATCH}},
   \code{\link{PUT}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/PUT.Rd
+++ b/man/PUT.Rd
@@ -74,3 +74,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{HEAD}}, \code{\link{PATCH}},
   \code{\link{POST}}, \code{\link{VERB}}
 }
+\concept{http methods}

--- a/man/VERB.Rd
+++ b/man/VERB.Rd
@@ -75,3 +75,4 @@ Other http methods: \code{\link{BROWSE}},
   \code{\link{HEAD}}, \code{\link{PATCH}},
   \code{\link{POST}}, \code{\link{PUT}}
 }
+\concept{http methods}

--- a/man/add_headers.Rd
+++ b/man/add_headers.Rd
@@ -38,3 +38,4 @@ Other config: \code{\link{authenticate}},
   \code{\link{timeout}}, \code{\link{use_proxy}},
   \code{\link{user_agent}}, \code{\link{verbose}}
 }
+\concept{config}

--- a/man/authenticate.Rd
+++ b/man/authenticate.Rd
@@ -30,3 +30,4 @@ Other config: \code{\link{add_headers}},
   \code{\link{timeout}}, \code{\link{use_proxy}},
   \code{\link{user_agent}}, \code{\link{verbose}}
 }
+\concept{config}

--- a/man/config.Rd
+++ b/man/config.Rd
@@ -61,3 +61,5 @@ Other config: \code{\link{add_headers}},
 Other ways to set configuration: \code{\link{set_config}},
   \code{\link{with_config}}
 }
+\concept{config}
+\concept{ways to set configuration}

--- a/man/content.Rd
+++ b/man/content.Rd
@@ -85,3 +85,4 @@ Other response methods: \code{\link{http_error}},
   \code{\link{http_status}}, \code{\link{response}},
   \code{\link{stop_for_status}}
 }
+\concept{response methods}

--- a/man/http_error.Rd
+++ b/man/http_error.Rd
@@ -40,3 +40,4 @@ Other response methods: \code{\link{content}},
   \code{\link{http_status}}, \code{\link{response}},
   \code{\link{stop_for_status}}
 }
+\concept{response methods}

--- a/man/http_status.Rd
+++ b/man/http_status.Rd
@@ -47,3 +47,4 @@ Other response methods: \code{\link{content}},
   \code{\link{http_error}}, \code{\link{response}},
   \code{\link{stop_for_status}}
 }
+\concept{response methods}

--- a/man/init_oauth2.0.Rd
+++ b/man/init_oauth2.0.Rd
@@ -11,12 +11,13 @@ init_oauth2.0(endpoint, app, scope = NULL, user_params = NULL,
   is_interactive = interactive(), use_basic_auth = FALSE,
   config_init = list(), client_credentials = FALSE)
 
-oauth2.0_authorize_url(endpoint, app, scope, redirect_uri = app$redirect_uri,
-  state = nonce())
+oauth2.0_authorize_url(endpoint, app, scope,
+  redirect_uri = app$redirect_uri, state = nonce())
 
-oauth2.0_access_token(endpoint, app, code, user_params = NULL, type = NULL,
-  use_basic_auth = FALSE, redirect_uri = app$redirect_uri,
-  client_credentials = FALSE, config = list())
+oauth2.0_access_token(endpoint, app, code, user_params = NULL,
+  type = NULL, use_basic_auth = FALSE,
+  redirect_uri = app$redirect_uri, client_credentials = FALSE,
+  config = list())
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}

--- a/man/jwt_signature.Rd
+++ b/man/jwt_signature.Rd
@@ -5,8 +5,8 @@
 \title{Generate a JWT signature given credentials.}
 \usage{
 jwt_signature(credentials, scope, aud, sub = NULL,
-  iat = as.integer(Sys.time()), exp = iat + duration, duration = 60L *
-  60L)
+  iat = as.integer(Sys.time()), exp = iat + duration, duration = 60L
+  * 60L)
 }
 \arguments{
 \item{credentials}{Parsed contents of the credentials file.}

--- a/man/oauth1.0_token.Rd
+++ b/man/oauth1.0_token.Rd
@@ -42,3 +42,4 @@ Other OAuth: \code{\link{oauth2.0_token}},
   \code{\link{oauth_app}}, \code{\link{oauth_endpoint}},
   \code{\link{oauth_service_token}}
 }
+\concept{OAuth}

--- a/man/oauth2.0_token.Rd
+++ b/man/oauth2.0_token.Rd
@@ -5,9 +5,10 @@
 \title{Generate an oauth2.0 token.}
 \usage{
 oauth2.0_token(endpoint, app, scope = NULL, user_params = NULL,
-  type = NULL, use_oob = getOption("httr_oob_default"), as_header = TRUE,
-  use_basic_auth = FALSE, cache = getOption("httr_oauth_cache"),
-  config_init = list(), client_credentials = FALSE, credentials = NULL)
+  type = NULL, use_oob = getOption("httr_oob_default"),
+  as_header = TRUE, use_basic_auth = FALSE,
+  cache = getOption("httr_oauth_cache"), config_init = list(),
+  client_credentials = FALSE, credentials = NULL)
 }
 \arguments{
 \item{endpoint}{An OAuth endpoint, created by \code{\link{oauth_endpoint}}}
@@ -71,3 +72,4 @@ Other OAuth: \code{\link{oauth1.0_token}},
   \code{\link{oauth_app}}, \code{\link{oauth_endpoint}},
   \code{\link{oauth_service_token}}
 }
+\concept{OAuth}

--- a/man/oauth_app.Rd
+++ b/man/oauth_app.Rd
@@ -45,3 +45,4 @@ Other OAuth: \code{\link{oauth1.0_token}},
   \code{\link{oauth_endpoint}},
   \code{\link{oauth_service_token}}
 }
+\concept{OAuth}

--- a/man/oauth_endpoint.Rd
+++ b/man/oauth_endpoint.Rd
@@ -40,3 +40,4 @@ Other OAuth: \code{\link{oauth1.0_token}},
   \code{\link{oauth2.0_token}}, \code{\link{oauth_app}},
   \code{\link{oauth_service_token}}
 }
+\concept{OAuth}

--- a/man/oauth_service_token.Rd
+++ b/man/oauth_service_token.Rd
@@ -36,3 +36,4 @@ Other OAuth: \code{\link{oauth1.0_token}},
   \code{\link{oauth2.0_token}}, \code{\link{oauth_app}},
   \code{\link{oauth_endpoint}}
 }
+\concept{OAuth}

--- a/man/response.Rd
+++ b/man/response.Rd
@@ -26,3 +26,4 @@ Other response methods: \code{\link{content}},
   \code{\link{http_error}}, \code{\link{http_status}},
   \code{\link{stop_for_status}}
 }
+\concept{response methods}

--- a/man/set_config.Rd
+++ b/man/set_config.Rd
@@ -33,3 +33,4 @@ GET("http://google.com")
 Other ways to set configuration: \code{\link{config}},
   \code{\link{with_config}}
 }
+\concept{ways to set configuration}

--- a/man/set_cookies.Rd
+++ b/man/set_cookies.Rd
@@ -29,3 +29,4 @@ Other config: \code{\link{add_headers}},
   \code{\link{timeout}}, \code{\link{use_proxy}},
   \code{\link{user_agent}}, \code{\link{verbose}}
 }
+\concept{config}

--- a/man/sign_oauth.Rd
+++ b/man/sign_oauth.Rd
@@ -6,8 +6,8 @@
 \alias{sign_oauth2.0}
 \title{Sign an OAuth request}
 \usage{
-sign_oauth1.0(app, token = NULL, token_secret = NULL, as_header = TRUE,
-  ...)
+sign_oauth1.0(app, token = NULL, token_secret = NULL,
+  as_header = TRUE, ...)
 
 sign_oauth2.0(access_token, as_header = TRUE)
 }

--- a/man/stop_for_status.Rd
+++ b/man/stop_for_status.Rd
@@ -60,3 +60,4 @@ Other response methods: \code{\link{content}},
   \code{\link{http_error}}, \code{\link{http_status}},
   \code{\link{response}}
 }
+\concept{response methods}

--- a/man/timeout.Rd
+++ b/man/timeout.Rd
@@ -25,3 +25,4 @@ Other config: \code{\link{add_headers}},
   \code{\link{set_cookies}}, \code{\link{use_proxy}},
   \code{\link{user_agent}}, \code{\link{verbose}}
 }
+\concept{config}

--- a/man/use_proxy.Rd
+++ b/man/use_proxy.Rd
@@ -29,3 +29,4 @@ Other config: \code{\link{add_headers}},
   \code{\link{set_cookies}}, \code{\link{timeout}},
   \code{\link{user_agent}}, \code{\link{verbose}}
 }
+\concept{config}

--- a/man/user_agent.Rd
+++ b/man/user_agent.Rd
@@ -22,3 +22,4 @@ Other config: \code{\link{add_headers}},
   \code{\link{set_cookies}}, \code{\link{timeout}},
   \code{\link{use_proxy}}, \code{\link{verbose}}
 }
+\concept{config}

--- a/man/verbose.Rd
+++ b/man/verbose.Rd
@@ -4,7 +4,8 @@
 \alias{verbose}
 \title{Give verbose output.}
 \usage{
-verbose(data_out = TRUE, data_in = FALSE, info = FALSE, ssl = FALSE)
+verbose(data_out = TRUE, data_in = FALSE, info = FALSE,
+  ssl = FALSE)
 }
 \arguments{
 \item{data_out}{Show data sent to the server.}
@@ -70,3 +71,4 @@ Other config: \code{\link{add_headers}},
   \code{\link{set_cookies}}, \code{\link{timeout}},
   \code{\link{use_proxy}}, \code{\link{user_agent}}
 }
+\concept{config}

--- a/man/with_config.Rd
+++ b/man/with_config.Rd
@@ -36,3 +36,4 @@ with_verbose(GET("http://google.com"))
 Other ways to set configuration: \code{\link{config}},
   \code{\link{set_config}}
 }
+\concept{ways to set configuration}


### PR DESCRIPTION
rationale: the way httr::POST wrap's jsonlite::toJSON is not quite general enough