### PR TITLE
Change the default failure in parse_http_date() to NA with class Date

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httr 1.3.1.9000
 
+* The default value of `failure` argument in `parse_http_date()` is set to `structure(NA_real_, class = "Date")` so that the reponse with a "failure" date can be printed out correctly. (@shrektan, #544)
+
 # httr 1.3.1
 
 * Re-enable on-disk caching (accidentally disabled in #457) (#475)

--- a/R/date.R
+++ b/R/date.R
@@ -21,7 +21,7 @@
 #' parse_http_date("Sun Nov  6 08:49:37 1994")
 #'
 #' http_date(Sys.time())
-parse_http_date <- function(x, failure = NA) {
+parse_http_date <- function(x, failure = structure(NA_real_, class = "Date")) {
   if (length(x) == 0) return(NULL)
 
   fmts <- c(

--- a/man/parse_http_date.Rd
+++ b/man/parse_http_date.Rd
@@ -5,7 +5,7 @@
 \alias{http_date}
 \title{Parse and print http dates.}
 \usage{
-parse_http_date(x, failure = NA)
+parse_http_date(x, failure = structure(NA_real_, class = "Date"))
 
 http_date(x)
 }


### PR DESCRIPTION
The default value of `failure` argument in `parse_http_date()` should be NA with class Date.

Otherwise, `print.response()` may throw an unfriendly error.

On a Chinese-language Windows machine, I use plumber to build an REST API. The API returns the `header$date` in Chinese format by default, like "周三, 10 十月 2018 1:19:13 GMT". 

`parse_http_date()` will fail to parse it correctly and fall back to the default value of `failure``.

However, the default value of `failure` is set to `NA` (the logical value). Whenever I try to print the response, R will throw error saying:

`Error in prettyNum(.Internal(format(x, trim, digits, nsmall, width, 3L,  :   invalid 'trim' argument`

I believe the cause is https://github.com/r-lib/httr/blob/976289a3596dc01dc994f8fd743770a172bbecdb/R/response.r#L35


After this PR, the result can be printed successfully now.

```
Response [http://127.0.0.1:8001/reLoad]
  Date: NA
  Status: 200
  Content-Type: application/json
  Size: 2 B
```