### PR TITLE
Improve warnings for non-http methods (fix #537)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 * The default value of `failure` argument in `parse_http_date()` is set to `structure(NA_real_, class = "Date")` so that the reponse with a "failure" date can be printed out correctly. (@shrektan, #544)
 
+* Non-http(s) methods now give an informative warning that headers are not interpretable the same way, and header parsing only minimally occurs. (@billdenney, #537)
+
 # httr 1.3.1
 
 * Re-enable on-disk caching (accidentally disabled in #457) (#475)

--- a/R/http-get.r
+++ b/R/http-get.r
@@ -40,6 +40,8 @@
 #'   requests to the same host. See \code{\link{handle_pool}} for more
 #'   details.
 #'
+#' @return A \code{\link{response}} object.
+#'
 #' @family http methods
 #' @export
 #' @examples

--- a/R/request.R
+++ b/R/request.R
@@ -149,8 +149,15 @@ request_perform <- function(req, handle, refresh = TRUE) {
     return(request_perform(req, handle, refresh = FALSE))
   }
 
-  all_headers <- parse_headers(resp$headers)
-  headers <- last(all_headers)$headers
+  url_scheme <- parse_url(resp$url)$scheme
+  if (tolower(url_scheme) %in% c("http", "https")) {
+    all_headers <- parse_headers(resp$headers)
+    headers <- last(all_headers)$headers
+  } else {
+    warning("Non-http(s) scheme used (", url_scheme, "); headers and all_headers may not be interpretable.")
+    all_headers <- strsplit(rawToChar(resp$headers), "\r?\n")[[1]]
+    headers <- list(text = all_headers)
+  }
   if (!is.null(headers$date)) {
     date <- parse_http_date(headers$Date)
   } else {

--- a/R/response.r
+++ b/R/response.r
@@ -15,6 +15,10 @@
 #'   \item \code{time} request timing information
 #'   \item \code{config} configuration for the request
 #' }
+#' 
+#' @details For non-http(s) responses, some parts including the status and
+#'   header may not be interpretable the same way as http responses.
+#' 
 #' @name response
 #' @family response methods
 NULL

--- a/man/GET.Rd
+++ b/man/GET.Rd
@@ -26,6 +26,9 @@ connection time, and ensures that cookies are maintained over multiple
 requests to the same host. See \code{\link{handle_pool}} for more
 details.}
 }
+\value{
+A \code{\link{response}} object.
+}
 \description{
 GET a url.
 }

--- a/man/response.Rd
+++ b/man/response.Rd
@@ -20,6 +20,9 @@ fields:
   \item \code{time} request timing information
   \item \code{config} configuration for the request
 }
+
+For non-http(s) responses, some parts including the status and
+  header may not be interpretable the same way as http responses.
 }
 \seealso{
 Other response methods: \code{\link{content}},

--- a/tests/testthat/test-response.r
+++ b/tests/testthat/test-response.r
@@ -55,3 +55,12 @@ test_that("application/json responses parsed as lists", {
   test_user_agent()
   test_user_agent("gunicorn-client/0.1")
 })
+
+test_that("non-http methods warn and return something for headers", {
+  expect_warning(
+    r <- GET("ftp://speedtest.tele2.net/1KB.zip"),
+    regexp = "Non-http(s) scheme used",
+    fixed = TRUE
+  )
+  expect_equal(names(r$headers), "text")
+})


### PR DESCRIPTION
Fix #537, give more informative information for non-http methods.