### PR TITLE
Add an example about empty element in body for POST

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr (development version)
 
+* `POST` gains an example on how to use `encode = "raw"` for specific json
+string body (@cderv, #563)
+
 # httr 1.4.0
 
 ## OAuth

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -34,7 +34,15 @@
 #' POST(b2, body = list(x = "A simple text string"))
 #' POST(b2, body = list(y = upload_file(system.file("CITATION"))))
 #' POST(b2, body = list(x = "A simple text string"), encode = "json")
-#' 
+#'
+#' # body can also be provided as a json string directly to deal
+#' # with specific case, like an empty element in the json string.
+#' # passing as string directly
+#' POST(b2, body = '{"a":1,"b":{}}', encode = "raw")
+#' # or building the json string before
+#' json_body <- jsonlite::toJSON(list(a = 1, b = NULL), auto_unbox = TRUE)
+#' POST(b2, body = json_body, encode = "raw")
+#'
 #' # Various types of empty body:
 #' POST(b2, body = NULL, verbose())
 #' POST(b2, body = FALSE, verbose())

--- a/man/POST.Rd
+++ b/man/POST.Rd
@@ -68,6 +68,14 @@ POST(b2, body = list(x = "A simple text string"))
 POST(b2, body = list(y = upload_file(system.file("CITATION"))))
 POST(b2, body = list(x = "A simple text string"), encode = "json")
 
+# body can also be provided as a json string directly to deal
+# with specific case, like an empty element in the json string.
+# passing as string directly
+POST(b2, body = '{"a":1,"b":{}}', encode = "raw")
+# or building the json string before
+json_body <- jsonlite::toJSON(list(a = 1, b = NULL), auto_unbox = TRUE)
+POST(b2, body = json_body, encode = "raw")
+
 # Various types of empty body:
 POST(b2, body = NULL, verbose())
 POST(b2, body = FALSE, verbose())


### PR DESCRIPTION
Following discussion in #561, I added an example in POST for this specific case. This show how to use `encode = "raw"` for providing json when the automatic `encode = "json"` does not suit.

This cover also #539 question. 