### PR TITLE
Oauth2.0_access_token: priority to user parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 OAuth2.0 has been made somewhat more flexible in order to support more websites:
 
+* `oauth2.0_access_token` prioritize user parameters over endpoint (@denrou, #564)
+
 * `init_oauth2.0()` passes `use_basic_auth` onwards, enabling 
    basic authentication for OAuth 2.0 (@peterhartman, #484).
 

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -172,7 +172,7 @@ oauth2.0_access_token <- function(endpoint,
   ))
 
   if (!is.null(user_params)) {
-    req_params <- utils::modifyList(user_params, req_params)
+    req_params <- utils::modifyList(req_params, user_params)
   }
 
   # Send credentials using HTTP Basic or as parameters in the request body


### PR DESCRIPTION
In oauth2.0_access_token, a user have the possibility to add its own
parameters to the POST request.
Those parameters are merged with endpoints and app parameters.
When a conflict is detected, endpoints parameters are privileged.
It makes more sense to prioritize the user parameters to overwrite
endpoints parameters.

This solve #564 with:
`oauth2.0_access_token(endpoint, app, user_params = list(username = "username", password = "password", grant_type = "password"), code = NULL)`