### PR TITLE
added handling of simpleError in http_error (fixes #569)

### DIFF
--- a/R/response-status.r
+++ b/R/response-status.r
@@ -180,6 +180,11 @@ http_error.integer <- function(x, ...) {
 }
 
 #' @export
+http_error.simpleError <- function(x, ...){
+    FALSE
+}
+
+#' @export
 #' @rdname http_error
 #' @usage NULL
 url_success <- function(x, ...) {

--- a/tests/testthat/test-http-error.R
+++ b/tests/testthat/test-http-error.R
@@ -17,3 +17,9 @@ test_that("http_error works with integers", {
   expect_false(http_error(200L))
   expect_true(http_error(404L))
 })
+
+test_that("http_error works with simpleErrors", {
+    expect_error({
+        res <- RETRY("POST", "http://98d90a2a254647889e2e4c236fb576cd.com")
+    })
+})


### PR DESCRIPTION
This PR attempts to address #569 so that failed requests will return a more helpful error message. I hope you'll consider it!