### PR TITLE
update to working linkedin v2 API example

### DIFF
--- a/demo/oauth2-linkedin.r
+++ b/demo/oauth2-linkedin.r
@@ -15,8 +15,7 @@ myapp <- oauth_app("linkedin",
 )
 
 # 3. Get OAuth credentials and specify a scope your app has permission for
-token <- oauth2.0_token(endpoints, myapp,
-                        scope = "r_liteprofile")
+token <- oauth2.0_token(endpoints, myapp, scope = "r_liteprofile")
 
 # 4. Use API
 req <- GET("https://api.linkedin.com/v2/me", config(token = token))

--- a/demo/oauth2-linkedin.r
+++ b/demo/oauth2-linkedin.r
@@ -14,10 +14,11 @@ myapp <- oauth_app("linkedin",
   secret = "n7vBr3lokGOCDKCd"
 )
 
-# 3. Get OAuth credentials
-token <- oauth2.0_token(endpoints, myapp)
+# 3. Get OAuth credentials and specify a scope your app has permission for
+token <- oauth2.0_token(endpoints, myapp,
+                        scope = "r_liteprofile")
 
 # 4. Use API
-req <- GET("https://api.linkedin.com/v1/people/~", config(token = token))
+req <- GET("https://api.linkedin.com/v2/me", config(token = token))
 stop_for_status(req)
 content(req)


### PR DESCRIPTION
The old linkedin example doesn't work now as they have updated to v2 of the API.  This change updates to a working example, including explicitly giving the scope for basic profile information that a new LinkedIn user app gives you on first creation.