### PR TITLE
Fix RETRY() error-handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr (development version)
 
+* `RETRY()` now throws the correct error message if an error occurs during the 
+  request (@austin3dickey, #581).
+
 # httr 1.4.0
 
 ## OAuth

--- a/R/retry.R
+++ b/R/retry.R
@@ -77,12 +77,12 @@ RETRY <- function(verb, url = NULL, config = list(), ...,
 }
 
 retry_should_terminate <- function(i, times, resp, terminate_on, terminate_on_success) {
-  if (terminate_on_success && !http_error(resp)) {
-    TRUE
-  } else if (i >= times) {
+  if (i >= times) {
     TRUE
   } else if (inherits(resp, "error")) {
     FALSE
+  } else if (terminate_on_success && !http_error(resp)) {
+    TRUE
   } else if (!is.null(terminate_on)) {
     status_code(resp) %in% terminate_on
   } else {

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -13,3 +13,10 @@ test_that("sucessful requests terminate when terminate_on_success is true", {
   expect_true(should_terminate(200L))
   expect_false(should_terminate(400L))
 })
+
+test_that("if request_perform() throws an error, RETRY passes it on", {
+  expect_error(
+    RETRY("POST", "http://98d90a2a254647889e2e4c236fb576cd.com", times = 1),
+    regexp = "Could not resolve host"
+  )
+})


### PR DESCRIPTION
This PR fixes a few issues where an unsuccessful `request_perform()` during a `RETRY()` will prematurely fatal with the following error message:
```
Error in UseMethod("http_error") : no applicable method for 'http_error' applied to an object of class "c('simpleError', 'error', 'condition')"
```
Now, `RETRY()` will successfully retry in those cases. This fix was @hadley 's [suggestion](https://github.com/r-lib/httr/pull/572#issuecomment-477588255).

Fixes #569 
Fixes #574 