### PR TITLE
Uppercase methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * `RETRY()` now throws the correct error message if an error occurs during the 
   request (@austin3dickey, #581).
 
+* `VERB()` and `RETRY()` now automatically uppercase methods (@patr1ckm, #571).
+
 # httr 1.4.0
 
 ## OAuth

--- a/R/http-verb.R
+++ b/R/http-verb.R
@@ -14,13 +14,13 @@
 #' )
 #' stop_for_status(r)
 #' content(r)
-#'
+#' 
 #' VERB("POST", url = "http://httpbin.org/post")
 #' VERB("POST", url = "http://httpbin.org/post", body = "foobar")
 VERB <- function(verb, url = NULL, config = list(), ...,
                  body = NULL, encode = c("multipart", "form", "json", "raw"),
                  handle = NULL) {
   hu <- handle_url(handle, url, ...)
-  req <- request_build(toupper(verb), hu$url, body_config(body, match.arg(encode)), config, ...)
+  req <- request_build(verb, hu$url, body_config(body, match.arg(encode)), config, ...)
   request_perform(req, hu$handle$handle)
 }

--- a/R/http-verb.R
+++ b/R/http-verb.R
@@ -14,13 +14,13 @@
 #' )
 #' stop_for_status(r)
 #' content(r)
-#' 
+#'
 #' VERB("POST", url = "http://httpbin.org/post")
 #' VERB("POST", url = "http://httpbin.org/post", body = "foobar")
 VERB <- function(verb, url = NULL, config = list(), ...,
                  body = NULL, encode = c("multipart", "form", "json", "raw"),
                  handle = NULL) {
   hu <- handle_url(handle, url, ...)
-  req <- request_build(verb, hu$url, body_config(body, match.arg(encode)), config, ...)
+  req <- request_build(toupper(verb), hu$url, body_config(body, match.arg(encode)), config, ...)
   request_perform(req, hu$handle$handle)
 }

--- a/R/request.R
+++ b/R/request.R
@@ -94,7 +94,7 @@ request_combine <- function(x, y) {
 print.request <- function(x, ...) {
   cat("<request>\n")
   if (!is.null(x$method) && !is.null(x$url)) {
-    cat(toupper(x$method), " ", x$url, "\n", sep = "")
+    cat(x$method, " ", x$url, "\n", sep = "")
   }
   if (!is.null(x$output)) {
     cat("Output: ", class(x$output)[[1]], "\n", sep = "")

--- a/R/request.R
+++ b/R/request.R
@@ -67,7 +67,7 @@ request_build <- function(method, url, ...) {
 
   req <- Reduce(request_combine, extra, init = request())
 
-  req$method <- method
+  req$method <- toupper(method)
   req$url <- url
 
   req

--- a/tests/testthat/test-request.r
+++ b/tests/testthat/test-request.r
@@ -14,6 +14,11 @@ test_that("c.request merges headers", {
   )
 })
 
+test_that('request_build upper cases verbs', {
+  expect_equal(request_build('get', 'asdf.com')$method, "GET")
+  expect_equal(request_build('post', 'asdf.com')$method, "POST")
+})
+
 test_that("non-http methods don't parse headers", {
   # skip on travis to avoid hammering the FTP server, which doesn't
   # seem to be able to handle multiple simultaneous requests


### PR DESCRIPTION
This uses uppercase methods everywhere by default, for use primarily in `VERB` and `RETRY`. 

This approach does a bit of extra work but was easier to test. An alternative is to implement the change only for `VERB` and `RETRY`, which I can do if you prefer.

Note that the curl options in `request_prepare` will now be set for formerly lowercase `get` and `post` calls, which were handled as custom calls previously. 
```
    GET = req$options$httpget <- TRUE,
    POST = req$options$post <- TRUE,
```

The result is that 
```
httr::VERB('get', 'google.com')
```
Now returns a 200.

Fixes #571 .