### PR TITLE
Fix flaky RETRY unit test

### DIFF
--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -17,6 +17,6 @@ test_that("sucessful requests terminate when terminate_on_success is true", {
 test_that("if request_perform() throws an error, RETRY passes it on", {
   expect_error(
     RETRY("POST", "http://98d90a2a254647889e2e4c236fb576cd.com", times = 1),
-    regexp = "Could not resolve host"
+    regexp = "resolve host"
   )
 })


### PR DESCRIPTION
I noticed that recent builds of `httr` are failing (e.g. https://travis-ci.org/r-lib/httr/jobs/517331103) with an error like:

![image](https://user-images.githubusercontent.com/7608904/55766135-d33a6a00-5a38-11e9-8482-ae1b23c4218f.png)

I could not reproduce this problem on my Mac tonight, which suggests to me that it has something to do with different underlying versions of either the `curl` R package or `libcurl` in the CI environment vs. my local dev environment.

In this PR, I propose making the `regexp` in that test less specific. I do still think it's important to have _some_ `regexp` there to be sure you got the actual curl error surfaced (since that was the intent of #581).

Thanks for considering this. I think it will unblock #582 , #583 , and #585 