### PR TITLE
find_cert_bundle() check for CURL_CA_BUNDLE on all platforms

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -74,18 +74,23 @@ keep_last <- function(...) {
 }
 
 find_cert_bundle <- function() {
-  if (.Platform$OS.type != "windows") {
-    return()
-  }
 
   env <- Sys.getenv("CURL_CA_BUNDLE")
   if (!identical(env, "")) {
-    return(env)
+    if (file.exists(env)) {
+      return(env)
+    } else {
+      wrn <- paste("Environment variable CURL_CA_BUNDLE is set to", env, "but that file does not exist. Looking for CA bundle in $R_HOME/etc/curl-ca-bundle.crt")
+      warning(wrn)
+    }
   }
 
   bundled <- file.path(R.home("etc"), "curl-ca-bundle.crt")
   if (file.exists(bundled)) {
     return(bundled)
+  } else {
+    msg <- paste0("No CA bundle found at ", bundled, ", falling back to the openssl package's CA bundle.")
+    message(msg)
   }
 
   # Fall back to certificate bundle in openssl


### PR DESCRIPTION
Is there a reason this is only checked for on Windows? Linux users might also want to point the package to their system CA bundle (e.g. /etc/ssl/certs/ca-certificates.crt). I changed find_cert_bundle() to look for the CURL_CA_BUNDLE environment variable on all platforms. I also added a check to make sure that if CURL_CA_BUNDLE is set, it's set to a file that exists.