### PR TITLE
Do not override the CA bundle

### DIFF
--- a/R/request.R
+++ b/R/request.R
@@ -36,8 +36,7 @@ request_default <- function() {
   c(
     request(
       options = list(
-        useragent = default_ua(),
-        cainfo = find_cert_bundle()
+        useragent = default_ua()
       ),
       headers = c(Accept = "application/json, text/xml, application/xml, */*"),
       output = write_function("write_memory")


### PR DESCRIPTION
It is not needed and on recent versions of libcurl this actually replaces corporate Windows certs.

See issue here: https://github.com/jeroen/curl/issues/193