### PR TITLE
FIX: Retry-After header when quiet=TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@
 
 * `RETRY()` now throws the correct error message if an error occurs during the 
   request (@austin3dickey, #581).
+  
+* `RETRY()` now respects the `Retry-After` header in addition to `retry-after`
+including when `quiet = TRUE` (@patr1ckm, #614).
 
 # httr 1.4.0
 

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -20,3 +20,9 @@ test_that("if request_perform() throws an error, RETRY passes it on", {
     regexp = "resolve host"
   )
 })
+
+test_that("back_off_full_jitter respects Retry-After header", {
+  r <- response(status_code = 429, headers = list('Retry-After' = .01))
+  length <- backoff_full_jitter(0, r, pause_min = 0, quiet = TRUE)
+  expect_equal(length, .01)
+})


### PR DESCRIPTION
`RETRY` now respects `Retry-After` and `retry-after` headers. `Retry-After` is the official standard.  Also fixes a previous bug that ignores the `Retry-After` if `quiet=TRUE`.

Fixes #611 .