### PR TITLE
Add support for connections as body in POST and friends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * `parse_url()` now refers to RFC3986 for the parsing of the URL's 
   scheme, with a bit more permissive syntax (@ymarcon, #615).
 
+* `POST()` allows `body` to be a connection, in which case the body will be
+   streamed from the connection using chunked transfer encoding.
+   (@s-u, #641)
+
 # httr 1.4.1
 
 * Remove the default `cainfo` option on Windows. Providing a CA bundle is not 

--- a/R/http-post.r
+++ b/R/http-post.r
@@ -15,6 +15,9 @@
 #'     [content_type()] to tell the server what sort of data
 #'     you are sending.
 #'   * A named list: See details for encode.
+#'   * A connection: either an unopened connection or a binary connection
+#'     open for reading. Contents will be sent as-is using chunked
+#'     transfer encoding.
 #' @param encode If the body is a named list, how should it be encoded? Can be
 #'   one of form (application/x-www-form-urlencoded), multipart,
 #'   (multipart/form-data), or json (application/json).


### PR DESCRIPTION
Allows `body` to be a connection. It uses `readfunction` (just like `form_file`) and chunked transfer encoding to allow `POST`s of non-seekable content where length is not known a priori (e.g. `pipe()` or others). It is implemented in `body_config` so works really for any method that requires body.