### PR TITLE
accept() takes 'type' vectors with length > 1

### DIFF
--- a/R/headers.r
+++ b/R/headers.r
@@ -92,7 +92,7 @@ accept <- function(type) {
   stopifnot(is.character(type), length(type) > 0L)
   guess <- substr(type, 1, 1) == "."
   if (any(guess))
-      type[guess] <- mime::guess_type(type[guess], empty = NULL)
+    type[guess] <- mime::guess_type(type[guess], empty = NULL)
   add_headers("Accept" = paste(type, collapse = ", "))
 }
 

--- a/R/headers.r
+++ b/R/headers.r
@@ -89,10 +89,11 @@ content_type_xml <- function() content_type("application/xml")
 #' @export
 #' @rdname content_type
 accept <- function(type) {
-  if (substr(type, 1, 1) == ".") {
-    type <- mime::guess_type(type, empty = NULL)
-  }
-  add_headers("Accept" = type)
+  stopifnot(is.character(type), length(type) > 0L)
+  guess <- substr(type, 1, 1) == "."
+  if (any(guess))
+      type[guess] <- mime::guess_type(type[guess], empty = NULL)
+  add_headers("Accept" = paste(type, collapse = ", "))
 }
 
 #' @export

--- a/tests/testthat/test-header.r
+++ b/tests/testthat/test-header.r
@@ -11,6 +11,34 @@ test_that("Only last duplicated header kept when combined", {
   expect_equal(out$headers, c(x = "2"))
 })
 
+test_that("Accept allows vector lengths greater than 1", {
+    type <- character()
+    expect_error(accept(type))
+
+    type <- "application/json"
+    out <- accept(type)$headers
+    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+
+    type <- c("application/json", "text/plain")
+    out <- accept(type)$headers
+    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+
+    ext <- ".json"
+    type <- "application/json"
+    out <- accept(ext)$headers
+    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+
+    ext <- c(".json", ".txt")
+    type <- c("application/json", "text/plain")
+    out <- accept(ext)$headers
+    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+
+    ext <- c(".json", "text/plain")
+    type <- c("application/json", "text/plain")
+    out <- accept(ext)$headers
+    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+})
+
 # Getting ---------------------------------------------------------------------
 
 test_that("All headers captures headers from redirects", {

--- a/tests/testthat/test-header.r
+++ b/tests/testthat/test-header.r
@@ -12,31 +12,31 @@ test_that("Only last duplicated header kept when combined", {
 })
 
 test_that("Accept allows vector lengths greater than 1", {
-    type <- character()
-    expect_error(accept(type))
+  type <- character()
+  expect_error(accept(type))
 
-    type <- "application/json"
-    out <- accept(type)$headers
-    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+  type <- "application/json"
+  out <- accept(type)$headers
+  expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
 
-    type <- c("application/json", "text/plain")
-    out <- accept(type)$headers
-    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+  type <- c("application/json", "text/plain")
+  out <- accept(type)$headers
+  expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
 
-    ext <- ".json"
-    type <- "application/json"
-    out <- accept(ext)$headers
-    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+  ext <- ".json"
+  type <- "application/json"
+  out <- accept(ext)$headers
+  expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
 
-    ext <- c(".json", ".txt")
-    type <- c("application/json", "text/plain")
-    out <- accept(ext)$headers
-    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+  ext <- c(".json", ".txt")
+  type <- c("application/json", "text/plain")
+  out <- accept(ext)$headers
+  expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
 
-    ext <- c(".json", "text/plain")
-    type <- c("application/json", "text/plain")
-    out <- accept(ext)$headers
-    expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
+  ext <- c(".json", "text/plain")
+  type <- c("application/json", "text/plain")
+  out <- accept(ext)$headers
+  expect_identical(out, setNames(paste(type, collapse = ", "), "Accept"))
 })
 
 # Getting ---------------------------------------------------------------------


### PR DESCRIPTION
`Accept` headers can contain multiple types, e.g., `"application/json, text/plain"`, but `accept()` previously produced a warning (because `if (substr(type, 1, 1) == ".")` is non-scalar)  on vector arguments with length > 1