### PR TITLE
add a small snippet to ?timeout about further info on timeout

### DIFF
--- a/R/timeout.r
+++ b/R/timeout.r
@@ -3,7 +3,8 @@
 #' @param seconds number of seconds to wait for a response until giving up.
 #'   Can not be less than 1 ms.
 #' @family config
-#' @details This timeout is passed on to \code{\link[curl]{handle_setopt}}. See there and \code{\link[curl]{curl_options}} for more details.
+#' @details This timeout is passed on to [curl::handle_setopt()].
+#'   See there and [curl::curl_options()] for more details.
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/timeout.r
+++ b/R/timeout.r
@@ -3,6 +3,7 @@
 #' @param seconds number of seconds to wait for a response until giving up.
 #'   Can not be less than 1 ms.
 #' @family config
+#' @details This timeout is passed on to \code{\link[curl]{handle_setopt}}. See there and \code{\link[curl]{curl_options}} for more details.
 #' @export
 #' @examples
 #' \dontrun{

--- a/man/timeout.Rd
+++ b/man/timeout.Rd
@@ -13,6 +13,10 @@ Can not be less than 1 ms.}
 \description{
 Set maximum request time.
 }
+\details{
+This timeout is passed on to \code{\link[curl:handle_setopt]{curl::handle_setopt()}}.
+See there and \code{\link[curl:curl_options]{curl::curl_options()}} for more details.
+}
 \examples{
 \dontrun{
 GET("http://httpbin.org/delay/3", timeout(1))


### PR DESCRIPTION
Closes #658 

I opted for a very minimal version for now. As Jenny pointed out, it can be quite complicated. Not sure what's worth spelling out in `httr` vs. just redirecting to `curl`.

Happy to expand as needed.