### PR TITLE
Force numeric query params to not use scientific notation

### DIFF
--- a/R/url-query.r
+++ b/R/url-query.r
@@ -23,7 +23,12 @@ compose_query <- function(elements) {
   names <- curl::curl_escape(names(elements))
 
   encode <- function(x) {
-    if (inherits(x, "AsIs")) return(x)
+    if (inherits(x, "AsIs")) {
+      return(x)
+    }
+    if (is.numeric(x)) {
+      x <- format(x, scientific = FALSE)
+    }
     curl::curl_escape(x)
   }
   values <- vapply(elements, encode, character(1))

--- a/tests/testthat/test-url.r
+++ b/tests/testthat/test-url.r
@@ -124,3 +124,11 @@ test_that("I() prevents escaping", {
 test_that("null elements are dropped", {
   expect_equal(compose_query(list(x = 1, y = NULL)), "x=1")
 })
+
+test_that("scientific notation is avoided", {
+  expect_equal(compose_query(list(x = 1e5, y = 100000, z = 1.23e3)), "x=100000&y=100000&z=1230")
+})
+
+test_that("sentinel values are preserved", {
+  expect_equal(compose_query(list(x = NaN, y = Inf, z=NA)), "x=NaN&y=Inf&z=NA")
+})


### PR DESCRIPTION
Potential fix for https://github.com/r-dbi/bigrquery/issues/395

I work on the All of Us Researcher Workbench project (https://github.com/all-of-us/workbench) where we guide users to fetch data from BigQuery via the `bigrquery` package. The issue above has been affecting our users, so we wanted to take a swing at a fix.

**Rationale**
The approach taken here is to treat numbers as special by pre-formatting them (and forcing non-scientific notation) before passing the string on to the `curl::curl_escape` function. (The `curl_escape` function uses as.character to convert its arguments to strings.)

This PR takes a stance that the prior behavior of auto-converting from 10000 to '1e+5' is not desired. If a user of this library wants a query param with scientific notation, they may convert the number to a scientific-formatted string before passing it to `httr`.

**Testing**
- devtools::check() runs successfully.
- I confirmed that the new `scientific notation is avoided` test fails if the code change is commented out.

**Notes**
The formatting change on the line above is arguably out-of-scope for this PR, but the [style guide](https://style.tidyverse.org/syntax.html#inline-statements) does suggest that return calls should be enclosed in braces.