### PR TITLE
Implement optional "circuit-breaking" for RETRY()

### DIFF
--- a/R/handle.r
+++ b/R/handle.r
@@ -42,7 +42,8 @@ handle <- function(url, cookies = TRUE) {
   }
 
   h <- curl::new_handle()
-  structure(list(handle = h, url = url), class = "handle")
+  out <- list2env(list(handle = h, url = url), parent = emptyenv(), size = 2)
+  structure(out, class = "handle")
 }
 
 #' @export

--- a/man/RETRY.Rd
+++ b/man/RETRY.Rd
@@ -18,7 +18,9 @@ RETRY(
   handle = NULL,
   quiet = FALSE,
   terminate_on = NULL,
-  terminate_on_success = TRUE
+  terminate_on_success = TRUE,
+  failure_threshold = Inf,
+  failure_timeout = 30
 )
 }
 \arguments{
@@ -92,6 +94,15 @@ retrying while \code{\link[=http_error]{http_error()}} is \code{TRUE} for the re
 \item{terminate_on_success}{If \code{TRUE}, the default, this will
 automatically terminate when the request is successful, regardless of the
 value of \code{terminate_on}.}
+
+\item{failure_threshold}{If requests continue to fail even when retried up to
+this number of times, impose a timeout on all subsequent requests to this
+host/port combination (or \code{handle}, if given). This timeout will persist
+across subsequent calls to this function, and is intended to detect failing
+servers without needing to wait each time (a "circuit-breaker" pattern).}
+
+\item{failure_timeout}{Time to wait, in seconds, before retrying a request
+that has exceeded the failure threshold.}
 }
 \value{
 The last response. Note that if the request doesn't succeed after

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -21,3 +21,29 @@ test_that("if request_perform() throws an error, RETRY passes it on", {
     regexp = "resolve host"
   )
 })
+
+test_that("circuit breaking in RETRY works correctly", {
+  skip_on_cran()
+  # Should not RETRY immediately, since it failed 1 time above already.
+  expect_error(
+    RETRY(
+      "POST", "http://98d90a2a254647889e2e4c236fb576cd.com", times = 1,
+      failure_threshold = 1
+    ),
+    regexp = "Too many request failures"
+  )
+  expect_error(
+    RETRY(
+      "POST", "http://98d90a2a254647889e2e4c236fb576cd.com", times = 1,
+      failure_threshold = 2
+    ),
+    regexp = "resolve host"
+  )
+  expect_error(
+    RETRY(
+      "POST", "http://98d90a2a254647889e2e4c236fb576cd.com", times = 1,
+      failure_threshold = 2
+    ),
+    regexp = "Too many request failures"
+  )
+})


### PR DESCRIPTION
Retrying requests is a good way to make code robust against transient failures in the upstream API. However, even with exponential backoff, it still faces a fundamental challenge when the service at the other end is truly unavailable for more than a few seconds. In those cases, retrying solves nothing and actually creates two *more* problems:

1. Users have to wait an artificially long time for their requests to fail; and
2. We generate additional load for an already-struggling service.

(For public APIs, the latter might not be our problem, but it's not responsible behaviour, either.)

One can also end up in a "cascading failure" scenario, where a buildup of retries will DDoS the underlying service and prevent it from recovering, triggering retries and more latency further and further downstream until the whole system is unresponsive. (Which was the inspiration for this PR.)

The generally-accepted way to avoid these problems is by implementing the so-called "circuit breaker pattern" (popularised by Michael Nygard, [Martin Fowler](https://martinfowler.com/bliki/CircuitBreaker.html), and Neflix's [Hystrix library](https://github.com/Netflix/Hystrix/)): once a given failure threshold has been met, a circuit is "tripped" and additional calls will fail immediately for some period of time.

A circuit breaker solves both problems above: clients calling `RETRY()` suddenly become responsive again (since they no longer wait at all), and we avoid adding further upstream load.

This PR implements this pattern by tracking failures at the handle level, which is both a natural choice and also highly convenient given `httr`'s internals. Failures are currently defined as curl-level errors, HTTP 5xx status codes, and also HTTP 408, which is explicitly for client-side request timeouts. Once the circuit is tripped, all subsequent calls to `RETRY()` issue an error until a timeout has elapsed. Meanwhile, any successful response will reset the failure counter.

At present it's very hard to implement circuit-breaking *around* `RETRY()`, because the function doesn't expose information about retried requests (or whether they occurred at all). Moreover, `RETRY()` seems explicitly designed to help R users do the right thing by implementing backoff (correctly) for them. This makes me think that a feature like this belongs in-tree as well.

Outstanding questions:

* Should the error use a custom class?