### PR TITLE
get url via endpoint rather than just endpoint

### DIFF
--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -178,7 +178,7 @@ oauth2.0_access_token <- function(endpoint,
   # Send credentials using HTTP Basic or as parameters in the request body
   # See https://tools.ietf.org/html/rfc6749#section-2.3 (Client Authentication)
   if (isTRUE(use_basic_auth)) {
-    req <- POST(endpoint$access,
+    req <- POST(endpoint$access$ACCESS_URL,
       encode = "form",
       body = req_params,
       authenticate(app$key, app$secret, type = "basic"),
@@ -186,7 +186,7 @@ oauth2.0_access_token <- function(endpoint,
     )
   } else {
     req_params$client_secret <- app$secret
-    req <- POST(endpoint$access,
+    req <- POST(endpoint$access$ACCESS_URL,
       encode = "form",
       body = req_params,
       config = config


### PR DESCRIPTION
This is my first contribution so sorry if I'm not doing this right.

I was working with [this gist ](https://gist.github.com/hadley/144c406871768d0cbe66b0b810160528) on integrating oauth with shiny and was running into an issue with my own oauth endpoint. It looks like the endpoint needs to be accessed with endpoint$access$ACCESS_URL rather than just endpoint$access.

Please let me know if there's anything I should change!