### PR TITLE
Add oauth error for deleted client

### DIFF
--- a/R/oauth-error.r
+++ b/R/oauth-error.r
@@ -9,7 +9,9 @@ oauth2.0_errors <- c(
   "invalid_grant",
   "unauthorized_client",
   "unsupported_grant_type",
-  "invalid_scope"
+  "invalid_scope",
+  # has been seen in Google auth
+  "deleted_client"
 )
 
 # This implements error checking according to the OAuth2.0


### PR DESCRIPTION
This PR is more for discussion/thought. In any case, I have to implement what I've learned here in gargle itself.

We are hoping to equip gargle for the inevitable shutdown (and general rolling) of the built-in oauth app. I am exploring what happens when you try to renew a token made with an OAuth app that has subsequently been deleted. https://github.com/r-lib/gargle/issues/168

`refresh_oauth2.0()` and, more specifically, `find_oauth2.0_error()` and, even more specifically, the list of `oauth2.0_errors` is possibly too rigid. And when the refresh failure doesn't look exactly as anticipated, this has 2 downsides:

* Uninformative error is ultimately thrown
* Token that failed-to-refresh remains in the cache, probably leading to future refresh failures (as opposed to being deleted upon refresh failure, clearing the way for successful oauth dance on the next attempt)

See https://github.com/r-lib/httr/blob/26d3f02a9523934d0beec08b94331ad908eea815/R/oauth-refresh.R#L33-L44

`find_oauth2.0_error()` is documented like so:

```
# This implements error checking according to the OAuth2.0
# specification: https://tools.ietf.org/html/rfc6749#section-5.2
```

But it turns out, Google has no problem returning an error that isn't listed here, when the OAuth app ("client") has been deleted:

```
> httr::content(foofy)
$error
[1] "deleted_client"

$error_description
[1] "The OAuth client was deleted."
```

The easiest fix is to add `"deleted_client"` to `oauth2.0_errors` as I've done in this PR, just for demonstration purposes. A more general solution is to just be happy as long as the error code is 400 or 401 and the error content has an `error` field:

``` r
find_oauth2.0_error <- function(response) {
  if (!status_code(response) %in% oauth2.0_error_codes) {
    return(NULL)
  }

  content <- content(response)
  if (is.null(content$error)) {
    return(NULL)
  }

  list(
    error = content$error,
    error_description = content$error_description,
    error_uri = content$error_uri
  )
}
```

---

Real example of refreshing a token when the app has been deleted with current refresh code:

* Not a very informative error
* Unrefreshable token lives on in the cache, for future uninformative failure

``` r
> devtools::load_all(".")
ℹ Loading gargle
> doomed_app <- oauth_app_from_json(
+   "~/.R/gargle/oauth-app-to-delete.json",
+   "doomed-app"
+ )
> library(googledrive)
> drive_auth_configure(app = doomed_app)
> x <- drive_find(n_max = 20)
→ The googledrive package is requesting access to your Google account
  Select a pre-authorised account or enter '0' to obtain a new token
  Press Esc/Ctrl + C to cancel

1: jane@example.com

Selection: 1
Auto-refreshing stale OAuth token.
Error in get("refresh_oauth2.0", asNamespace("httr"))(self$endpoint, self$app,  : 
  Unauthorized (HTTP 401).
```

---

Same example after adding `"deleted_client"` to the recognized errors.

``` r
> devtools::load_all(".")
ℹ Loading gargle
> doomed_app <- oauth_app_from_json(
+   "~/.R/gargle/oauth-app-to-delete.json",
+   "doomed-app"
+ )
> library(googledrive)
> drive_auth_configure(app = doomed_app)
> x <- drive_find(n_max = 20)
→ The googledrive package is requesting access to your Google account
  Select a pre-authorised account or enter '0' to obtain a new token
  Press Esc/Ctrl + C to cancel

1: jane@example.com

Selection: 1
Auto-refreshing stale OAuth token.
Error: Client error: (401) Unauthorized
Invalid Credentials
  *       domain: global
  *       reason: authError
  *      message: Invalid Credentials
  * locationType: header
  *     location: Authorization
Run `rlang::last_error()` to see where the error occurred.
In addition: Warning message:
Unable to refresh token: deleted_client
The OAuth client was deleted. 
```