### PR TITLE
`request_perform()`: If the curl response does not return a valid url, use the request url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # httr (development version)
 
+* When calling `request_perform()` and `curl` returns an incomplete response
+  object, use the original request url instead of an empty url. (#697)
+
 # httr 1.4.2
 
 * Fix failing test.

--- a/R/request.R
+++ b/R/request.R
@@ -156,7 +156,14 @@ request_perform <- function(req, handle, refresh = TRUE) {
     return(request_perform(req, handle, refresh = FALSE))
   }
 
-  url_scheme <- parse_url(resp$url)$scheme
+  # If the response does not return a url, use the request url
+  if (isTRUE(nzchar(resp$url))) {
+    response_url <- resp$url
+  } else {
+    response_url <- req$url
+  }
+
+  url_scheme <- parse_url(response_url)$scheme
   is_http <- tolower(url_scheme) %in% c("http", "https")
   if (is_http) {
     all_headers <- parse_http_headers(resp$headers)
@@ -173,7 +180,7 @@ request_perform <- function(req, handle, refresh = TRUE) {
   }
 
   res <- response(
-    url = resp$url,
+    url = response_url,
     status_code = resp$status_code,
     headers = headers,
     all_headers = all_headers,


### PR DESCRIPTION
This change is involved in a wild goose chase of a bug. I hope the original problem is in https://github.com/jeroen/curl/issues/257.

Similar to https://github.com/rstudio/webdriver/pull/72, this PR should only be merge if no action comes from https://github.com/jeroen/curl/issues/257 . Marking this PR as a draft until a decision is made.

--------------------------

`resp` is somehow being returns as a stub of information from curl. This means the url is `""`, which cascades into many different errors. There are other unexpected pieces of information, such as no headers, but if a plausible url is provided then we can limp out of the function. 

If the `resp$url` equals `""` and it is not handled, then the `url_scheme` equals `NULL` which causes `is_http` to be `logical(0)`. This throws an error: `Error in if (is_http) {: argument is of length zero`. This error does not make sense when the original request url was valid.