### PR TITLE
Make it clear httr uses different default than jsonlite

### DIFF
--- a/R/content.r
+++ b/R/content.r
@@ -12,7 +12,8 @@
 #' * `text/xml`: [xml2::read_xml()]
 #' * `text/csv`: [readr::read_csv()]
 #' * `text/tab-separated-values`: [readr::read_tsv()]
-#' * `application/json`: [jsonlite::fromJSON()]
+#' * `application/json`: [jsonlite::fromJSON()], but with a
+#' `simplifyVector = FALSE` default
 #' * `application/x-www-form-urlencoded`: `parse_query`
 #' * `image/jpeg`: [jpeg::readJPEG()]
 #' * `image/png`: [png::readPNG()]

--- a/man/content.Rd
+++ b/man/content.Rd
@@ -50,7 +50,8 @@ does its best to guess which output is most appropriate.
 \item \code{text/xml}: \code{\link[xml2:read_xml]{xml2::read_xml()}}
 \item \code{text/csv}: \code{\link[readr:read_delim]{readr::read_csv()}}
 \item \code{text/tab-separated-values}: \code{\link[readr:read_delim]{readr::read_tsv()}}
-\item \code{application/json}: \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}
+\item \code{application/json}: \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}, but with a
+\code{simplifyVector = FALSE} default
 \item \code{application/x-www-form-urlencoded}: \code{parse_query}
 \item \code{image/jpeg}: \code{\link[jpeg:readJPEG]{jpeg::readJPEG()}}
 \item \code{image/png}: \code{\link[png:readPNG]{png::readPNG()}}


### PR DESCRIPTION
`jsonlite::fromJSON` default uses `simplifyVector = TRUE`: https://github.com/jeroen/jsonlite/blob/master/R/fromJSON.R#L78
so making it so the docs noted that `httr::content` default was different.  Related to https://github.com/r-lib/httr/issues/85, but that's likely very dated (esp since it refers to `RJSONIO` vs. `jsonlite`)

@jeroen