### PR TITLE
Fixed typo in content_type() documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = FALSE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/headers.r
+++ b/R/headers.r
@@ -47,7 +47,7 @@ add_headers <- function(..., .headers = character()) {
 
 #' Set content-type and accept headers.
 #'
-#' These are convenient wrappers aroud [add_headers()].
+#' These are convenient wrappers around [add_headers()].
 #'
 #' `accept_json`/`accept_xml` and
 #' `content_type_json`/`content_type_xml` are useful shortcuts to

--- a/man/content_type.Rd
+++ b/man/content_type.Rd
@@ -26,7 +26,7 @@ accept_xml()
 with \code{.}) will guess the mime type using \code{\link[mime:guess_type]{mime::guess_type()}}.}
 }
 \description{
-These are convenient wrappers aroud \code{\link[=add_headers]{add_headers()}}.
+These are convenient wrappers around \code{\link[=add_headers]{add_headers()}}.
 }
 \details{
 \code{accept_json}/\code{accept_xml} and


### PR DESCRIPTION
There was a typo in the content_type() documentation, I fixed it and ran devtools::document() to carry it over to the corresponding .Rd file.