### PR TITLE
Fix argument value in return value docs

### DIFF
--- a/R/content.r
+++ b/R/content.r
@@ -49,7 +49,7 @@
 #' re-encoded to UTF-8. If this encoding fails (usually because the page
 #' declares an incorrect encoding), `content()` will return `NA`.
 #'
-#' For "auto", a parsed R object.
+#' For "parsed", a parsed R object.
 #' @export
 #' @examples
 #' r <- POST("http://httpbin.org/post", body = list(a = 1, b = 2))

--- a/man/content.Rd
+++ b/man/content.Rd
@@ -34,7 +34,7 @@ For "text", a character vector of length 1. The character vector is always
 re-encoded to UTF-8. If this encoding fails (usually because the page
 declares an incorrect encoding), \code{content()} will return \code{NA}.
 
-For "auto", a parsed R object.
+For "parsed", a parsed R object.
 }
 \description{
 There are currently three ways to retrieve the contents of a request:


### PR DESCRIPTION
`as = "auto"` is not an authorised value. Based on the text, it should actually read `"parsed"`. This PR fixes this.