### PR TITLE
Add an escape control in `set_cookies`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = FALSE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/cookies.r
+++ b/R/cookies.r
@@ -2,20 +2,25 @@
 #'
 #' @param ... a named cookie values
 #' @param .cookies a named character vector
+#' @param escape If `escape = FALSE`, the character in the cookies will not be escaped. Default is `TRUE`
 #' @export
 #' @family config
 #' @seealso [cookies()] to see cookies in response.
 #' @examples
 #' set_cookies(a = 1, b = 2)
 #' set_cookies(.cookies = c(a = "1", b = "2"))
-#' 
+#'
 #' GET("http://httpbin.org/cookies")
 #' GET("http://httpbin.org/cookies", set_cookies(a = 1, b = 2))
-set_cookies <- function(..., .cookies = character(0)) {
+set_cookies <- function(..., .cookies = character(0), escape = TRUE) {
   cookies <- c(..., .cookies)
   stopifnot(is.character(cookies))
 
-  cookies_str <- vapply(cookies, curl::curl_escape, FUN.VALUE = character(1))
+  if(escape){
+    cookies_str <- vapply(cookies, curl::curl_escape, FUN.VALUE = character(1))
+  } else {
+    cookies_str <- cookies
+  }
 
   cookie <- paste(names(cookies), cookies_str, sep = "=", collapse = ";")
 

--- a/man/set_cookies.Rd
+++ b/man/set_cookies.Rd
@@ -4,12 +4,14 @@
 \alias{set_cookies}
 \title{Set cookies.}
 \usage{
-set_cookies(..., .cookies = character(0))
+set_cookies(..., .cookies = character(0), escape = TRUE)
 }
 \arguments{
 \item{...}{a named cookie values}
 
 \item{.cookies}{a named character vector}
+
+\item{escape}{If \code{escape = FALSE}, the character in the cookies will not be escaped. Default is \code{TRUE}}
 }
 \description{
 Set cookies.


### PR DESCRIPTION
In some cases, we will get some cookies which is no need to make escape. With the missing of escape control, the twice cookies escape will generate wrong cookies.

To avoid the potential error, I have added `escape` argument in `httr:set_cookies`.