### PR TITLE
Refresh the R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,13 +28,12 @@ jobs:
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
 
-          # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/R/content.r
+++ b/R/content.r
@@ -57,7 +57,7 @@
 #' cat(content(r, "text"), "\n") # text content
 #' content(r, "raw") # raw bytes from server
 #'
-#' rlogo <- content(GET("http://cran.r-project.org/Rlogo.jpg"))
+#' rlogo <- content(GET("https://httpbin.org/image/png"))
 #' plot(0:1, 0:1, type = "n")
 #' rasterImage(rlogo, 0, 0, 1, 1)
 #' @aliases text_content parsed_content

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/httr)](https://cran.r-project.org/package=httr)
-[![R-CMD-check](https://github.com/r-lib/httr/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/httr/actions)
+[![R-CMD-check](https://github.com/r-lib/httr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/httr/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/r-lib/httr/branch/master/graph/badge.svg)](https://app.codecov.io/gh/r-lib/httr?branch=main)
 <!-- badges: end -->
 

--- a/man/content.Rd
+++ b/man/content.Rd
@@ -75,7 +75,7 @@ content(r) # automatically parses JSON
 cat(content(r, "text"), "\n") # text content
 content(r, "raw") # raw bytes from server
 
-rlogo <- content(GET("http://cran.r-project.org/Rlogo.jpg"))
+rlogo <- content(GET("https://httpbin.org/image/png"))
 plot(0:1, 0:1, type = "n")
 rasterImage(rlogo, 0, 0, 1, 1)
 }


### PR DESCRIPTION
Mostly to get onto ubuntu-latest

But also: CI has been failing for a long time on windows-latest (3.6) because of some jpeg issue I don't care to sort out. Let's just read a PNG in the example.