### PR TITLE
Make `is_interactive()` react to "rlang_interactive" option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # httr (development version)
 
+* An internal helper that checks for an interactive session in the OOB flow now
+  honors the `"rlang_interactive"` global option, in case it's necessary to
+  declare the session to be interactive (enough) for OOB (@jennybc, #734).
+
 # httr 1.4.4
 
 * Fix intermittent failing test.

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -211,11 +211,9 @@ check_scope <- function(x) {
   paste(x, collapse = " ")
 }
 
-# Two reasons for wrapping base::interactive()
-# 1. Wrap in a non-primitive function, so it can be mocked for testing.
-# 2. gargle needs to access (pseudo-)OOB flow from Google Colab, so we need to
-#    be able to use the "rlang_interactive" option to signal that we are in
-#    an interactive environment.
+# gargle needs to access (pseudo-)OOB flow from Google Colab, so we need to
+# be able to use the "rlang_interactive" option to signal that we are in
+# an interactive environment. httr does not have an rlang dependency.
 is_interactive <- function() {
   getOption("rlang_interactive") %||% interactive()
 }

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -211,8 +211,14 @@ check_scope <- function(x) {
   paste(x, collapse = " ")
 }
 
-# Wrap base::interactive in a non-primitive function so that the call can be mocked for testing
-is_interactive <- function() interactive()
+# Two reasons for wrapping base::interactive()
+# 1. Wrap in a non-primitive function, so it can be mocked for testing.
+# 2. gargle needs to access (pseudo-)OOB flow from Google Colab, so we need to
+#    be able to use the "rlang_interactive" option to signal that we are in
+#    an interactive environment.
+is_interactive <- function() {
+  getOption("rlang_interactive") %||% interactive()
+}
 
 check_oob <- function(use_oob, oob_value = NULL) {
   if (!is.logical(use_oob) || length(use_oob) != 1) {

--- a/R/oauth-init.R
+++ b/R/oauth-init.R
@@ -213,7 +213,7 @@ check_scope <- function(x) {
 
 # gargle needs to access (pseudo-)OOB flow from Google Colab, so we need to
 # be able to use the "rlang_interactive" option to signal that we are in
-# an interactive environment. httr does not have an rlang dependency.
+# an environment that is interactive (enough) to complete this flow.
 is_interactive <- function() {
   getOption("rlang_interactive") %||% interactive()
 }

--- a/tests/testthat/test-oauth.R
+++ b/tests/testthat/test-oauth.R
@@ -111,13 +111,19 @@ test_that("oob must be a flag", {
 })
 
 test_that("can not use oob in non-interactive session", {
+  old <- options()
+  on.exit(options(old))
+  options(rlang_interactive = FALSE)
+
   expect_error(check_oob(TRUE), "interactive")
 })
 
 test_that("can not use custom oob value without enabling oob", {
   testthat::skip_if_not_installed("httpuv")
-  with_mock(
-    `httr:::is_interactive` = function() TRUE,
-    expect_error(check_oob(FALSE, "custom_value"), "custom oob value")
-  )
+
+  old <- options()
+  on.exit(options(old))
+  options(rlang_interactive = TRUE)
+
+  expect_error(check_oob(FALSE, "custom_value"), "custom oob value")
 })


### PR DESCRIPTION
This will allow me to make gargle's pseudo-OOB flow work in Google Colab, which would be really nice.

Relates to https://github.com/r-lib/gargle/pull/237, where I currently have `utils::assignInNamespace("is_interactive", rlang::is_interactive, ns = "httr")` in `.onLoad()`, but I can remove that if this PR gets merged and released. I don't think I could release gargle to CRAN with `assignInNamespace()`.

Relates to https://github.com/r-lib/gargle/issues/140 